### PR TITLE
Upgrade to OpenSSL 0.7.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ version = "~0.1.0"
 default-features = false
 
 [dependencies.openssl]
-version = "~0.6.0"
+version = "~0.7.4"
 optional = true
 
 [dependencies.unix_socket]

--- a/src/io.rs
+++ b/src/io.rs
@@ -313,7 +313,7 @@ impl Stream {
                     let stream = opt_stream.take().unwrap();
                     match stream {
                         TcpStream::Insecure(stream) => {
-                            let ssl_stream = try!(ssl::SslStream::new(&ctx, stream));
+                            let ssl_stream = try!(ssl::SslStream::connect(&ctx, stream));
                             Ok(Stream::TcpStream(Some(TcpStream::Secure(ssl_stream))))
                         },
                         _ => unreachable!(),


### PR DESCRIPTION
I ran into issues when trying to use Hyper and Mysql in the same project as they require different OpenSSL versions.  Since Hyper seems to be using the latest version, this PR pulls mysql up to the same version.