### PR TITLE
Update lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! ```toml
 //! [dependencies.mysql]
-//! mysql = "*"
+//! version = "*"
 //! default-features = false
 //! features = ["socket"]
 //! ```
@@ -26,7 +26,7 @@
 //!
 //! ```toml
 //! [dependencies.mysql]
-//! mysql = "*"
+//! version = "*"
 //! default-features = false
 //! features = ["pipe"]
 //! ```


### PR DESCRIPTION
Fixes Cargo.toml example from generating  `warning: dependency (regex) specified without providing a local path, Git repository, or version to use.` warnings, which will be failures in the future.