### PR TITLE
Add support for UUIDs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "mysql"
-version = "5.0.0"
+version = "5.1.0"
 authors = ["blackbeam"]
 description = "Mysql client library implemented in rust"
 license = "MIT"
@@ -70,5 +70,9 @@ version = "~0.5"
 optional = true
 
 [dependencies.named_pipe]
+version = "~0.2"
+optional = true
+
+[dependencies.uuid]
 version = "~0.2"
 optional = true

--- a/README.md
+++ b/README.md
@@ -37,4 +37,16 @@ default-features = false
 features = ["pipe"]
 ```
 
+#### Optional features
+You can compile rust-mysql-simple with the `uuid` feature, which makes it possible to use UUIDs with MySQL conveniently.
+
+The `uuid` feature depends on the `uuid` crate and UUIDs are assumed to be binary encoded in MySQL. So make sure that your MySQL fields are binary(16).
+
+To activate the `uuid` feature, add it to the `features` list:
+
+```toml
+[dependencies]
+mysql = { version = "*", features = ["uuid"] }
+```
+
 [Simple example](http://blackbeam.org/doc/mysql/index.html#example)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,19 @@
 //! features = ["pipe"]
 //! ```
 //!
+//! #### Optional features
+//!
+//! You can compile rust-mysql-simple with the `uuid` feature, which makes it possible to use UUIDs with MySQL conveniently.
+//!
+//! The `uuid` feature depends on the `uuid` crate and UUIDs are assumed to be binary encoded in MySQL. So make sure that your MySQL fields are binary(16).
+//!
+//! To activate the `uuid` feature, add it to the `features` list:
+//!
+//! ```toml
+//! [dependencies]
+//! mysql = { version = "*", features = ["uuid"] }
+//! ```
+//!
 //! #### Example
 //!
 //! ```rust
@@ -163,6 +176,8 @@ mod io;
 pub mod value;
 pub mod conn;
 mod named_params;
+#[cfg(feature = "uuid")]
+mod uuid;
 
 #[doc(inline)]
 pub use conn::Column;

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -1,0 +1,71 @@
+extern crate uuid;
+
+use self::uuid::Uuid;
+
+use super::value::{
+    Value,
+    FromValue,
+    ConvIr,
+};
+use super::error::{
+    Error,
+    Result as MyResult,
+};
+
+impl Into<Value> for Uuid {
+    fn into(self) -> Value {
+        Value::Bytes(self.as_bytes().to_vec())
+    }
+}
+
+#[derive(Debug)]
+pub struct UuidIr {
+    val: Uuid,
+}
+
+impl ConvIr<Uuid> for UuidIr {
+    fn new(v: Value) -> MyResult<UuidIr> {
+        match v {
+            Value::Bytes(bytes) => match Uuid::from_bytes(bytes.as_slice()) {
+                Ok(val) => Ok(UuidIr { val: val }),
+                Err(_) => Err(Error::FromValueError(Value::Bytes(bytes))),
+            },
+            v => Err(Error::FromValueError(v)),
+        }
+    }
+    fn commit(self) -> Uuid {
+        self.val
+    }
+    fn rollback(self) -> Value {
+        Value::Bytes(self.val.as_bytes().to_vec())
+    }
+}
+
+impl FromValue for Uuid {
+    type Intermediate = UuidIr;
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::value::Value::Bytes;
+    use super::super::from_value;
+    use super::uuid::Uuid;
+
+    #[test]
+    fn should_convert_Bytes_to_Uuid() {
+        let bytes = vec![0x0e, 0x87, 0x6d, 0x72, 0xc7, 0xb2, 0x4c, 0x00, 0x8c, 0x56, 0x44, 0xee, 0xac, 0x10, 0x15, 0xd1];
+        assert_eq!(
+            Uuid::parse_str("0e876d72-c7b2-4c00-8c56-44eeac1015d1").unwrap(),
+            from_value::<Uuid>(Bytes(bytes))
+        );
+    }
+
+    #[test]
+    fn should_convert_Uuid_to_Bytes() {
+        let bytes = vec![0x0e, 0x87, 0x6d, 0x72, 0xc7, 0xb2, 0x4c, 0x00, 0x8c, 0x56, 0x44, 0xee, 0xac, 0x10, 0x15, 0xd1];
+        assert_eq!(
+            Bytes(bytes),
+            Uuid::parse_str("0e876d72-c7b2-4c00-8c56-44eeac1015d1").unwrap().into()
+        );
+    }
+}

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -21,13 +21,14 @@ impl Into<Value> for Uuid {
 #[derive(Debug)]
 pub struct UuidIr {
     val: Uuid,
+    bytes: Vec<u8>,
 }
 
 impl ConvIr<Uuid> for UuidIr {
     fn new(v: Value) -> MyResult<UuidIr> {
         match v {
             Value::Bytes(bytes) => match Uuid::from_bytes(bytes.as_slice()) {
-                Ok(val) => Ok(UuidIr { val: val }),
+                Ok(val) => Ok(UuidIr { val: val, bytes: bytes }),
                 Err(_) => Err(Error::FromValueError(Value::Bytes(bytes))),
             },
             v => Err(Error::FromValueError(v)),
@@ -37,7 +38,7 @@ impl ConvIr<Uuid> for UuidIr {
         self.val
     }
     fn rollback(self) -> Value {
-        Value::Bytes(self.val.as_bytes().to_vec())
+        Value::Bytes(self.bytes)
     }
 }
 


### PR DESCRIPTION
This commit implements the FromValue trait for the Uuid type.
It is quite convenient to do that because it reduces the boilerplate when writing SQL queries.
It's an optional feature so, no new dependencies are introduced by default.

I understand that UUIDs are not an official SQL type, but since traits can only be implemented in either the crate the trait or the struct was defined in, this feature has to be implemented in either the uuid or the mysql crate. And doing that in the uuid crate would obviously be wrong.