### PR TITLE
Fix mismatch between MySQL DATE type and chrono::NaiveDate

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -1867,7 +1867,10 @@ fn parse_mysql_datetime_string(bytes: &[u8]) -> Option<(u32, u32, u32, u32, u32,
     }).map(|capts| {
         let year = capts.at(1).unwrap().parse::<u32>().unwrap();
         let month = capts.at(2).unwrap().parse::<u32>().unwrap();
-        let day = capts.at(3).unwrap().parse::<u32>().unwrap();
+        let mut day = capts.at(3).unwrap().parse::<u32>().unwrap();
+        if day == 0 {
+            day = 1;
+        }
         let (hour, minute, second, micros) = if capts.len() > 4 {
             let hour = capts.at(4).unwrap().parse::<u32>().unwrap();
             let minute = capts.at(5).unwrap().parse::<u32>().unwrap();


### PR DESCRIPTION
Issue:

MySQL text based protocol, and MySQL input sanitizer are completely okay with a date like `2016-07-00`.. But `chrono::NaiveDate::from_ymd_opt` will return `Option::None` when passed a day value of `0`. This effectively breaks this libraries ability to read the MySQL `DATE` column.

Solution:

This patch fixes this problem, so the day value cannot be 0, in the event it is, it returns a 1 instead. I feel this is an OKAY compromise. As the 0th day, is normally the 1st day. Also it is rather rare to see 00. 

The only other solution is to drop chrono, and use strings.


