### PR TITLE
Publish chrono and time crates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@
 #[cfg(feature = "nightly")]
 extern crate test;
 
-extern crate time;
+pub extern crate time;
 #[cfg(feature = "openssl")]
 extern crate openssl;
 extern crate regex;
@@ -165,7 +165,7 @@ extern crate named_pipe;
 extern crate url;
 extern crate bufstream;
 extern crate fnv;
-extern crate chrono;
+pub extern crate chrono;
 extern crate twox_hash;
 
 mod scramble;


### PR DESCRIPTION
This crate implements own trait for external types. It's better to keep that crates published for convenience.

Reason:
```rust
impl FromValue for NaiveDateTime
impl FromValue for NaiveDate
impl FromValue for NaiveTime
impl FromValue for Timespec
impl FromValue for Duration
impl FromValue for Duration
```