### PR TITLE
Fix build error: "struct field shorthands are unstable"

### DIFF
--- a/src/io/tcp.rs
+++ b/src/io/tcp.rs
@@ -63,7 +63,7 @@ impl<T: ToSocketAddrs> MyTcpBuilder<T> {
 
     pub fn new(address: T) -> MyTcpBuilder<T> {
         MyTcpBuilder {
-            address,
+            address: address,
             bind_address: None,
             connect_timeout: None,
             read_timeout: None,


### PR DESCRIPTION
I caught the error as below in building this library (ver 11.1.0).

```
error: struct field shorthands are unstable (see issue #37340)
  --> src/io/tcp.rs:66:13
   |
66 |             address,
   |             ^^^^^^^

error: aborting due to previous error
```

In the future, struct field must be described specifically.
See [#37340](https://github.com/rust-lang/rust/issues/37340) on rust-lang/rust repo.

My Rust environment is below.
```console
$ cargo -V
cargo-0.17.0-nightly (f9e5481 2017-03-03)
$ rustc -V
rustc 1.16.0 (30cf806ef 2017-03-10)
```

Thanks.