### PR TITLE
Fix build on nightly rustc

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -322,7 +322,7 @@ pub enum Stream {
     TcpStream(Option<TcpStream>),
 }
 
-trait IoPack: io::Read + io::Write + io::BufRead + 'static { }
+pub trait IoPack: io::Read + io::Write + io::BufRead + 'static { }
 
 impl<T: io::Read + io::Write + 'static> IoPack for BufStream<T> { }
 


### PR DESCRIPTION
Hi.
https://github.com/rust-lang/rust/pull/42125 is going to fix some holes in `rustc`'s privacy checker.
Unfortunately, it can break code sometimes.
`crates.io` testing found 3 unexpected regressions, including this crate.
This PR updates the code to build successfully with https://github.com/rust-lang/rust/pull/42125