### PR TITLE
Allow to pass &str or String

### DIFF
--- a/src/conn/opts.rs
+++ b/src/conn/opts.rs
@@ -472,8 +472,8 @@ fn get_opts_db_name_from_url(url: &Url) -> Option<String> {
     }
 }
 
-fn from_url_basic(url_str: &str) -> Result<(Opts, Vec<(String, String)>), UrlError> {
-    let url = Url::parse(url_str)?;
+fn from_url_basic<S: Into<String>>(url_str: S) -> Result<(Opts, Vec<(String, String)>), UrlError> {
+    let url = Url::parse(&url_str.into())?;
     if url.scheme() != "mysql" {
         return Err(UrlError::UnsupportedScheme(url.scheme().to_string()));
     }
@@ -499,7 +499,7 @@ fn from_url_basic(url_str: &str) -> Result<(Opts, Vec<(String, String)>), UrlErr
     Ok((opts, query_pairs))
 }
 
-fn from_url(url: &str) -> Result<Opts, UrlError> {
+fn from_url<S: Into<String>>(url: S) -> Result<Opts, UrlError> {
     let (mut opts, query_pairs) = from_url_basic(url)?;
     for (key, value) in query_pairs {
         if key == "prefer_socket" {
@@ -547,9 +547,9 @@ fn from_url(url: &str) -> Result<Opts, UrlError> {
     Ok(opts)
 }
 
-impl<'a> From<&'a str> for Opts {
-    fn from(url: &'a str) -> Opts {
-        match from_url(url) {
+impl<S: Into<String>> From<S> for Opts {
+    fn from(url: S) -> Opts {
+        match from_url(url.into()) {
             Ok(opts) => opts,
             Err(err) => panic!("{}", err),
         }

--- a/src/conn/opts.rs
+++ b/src/conn/opts.rs
@@ -472,8 +472,8 @@ fn get_opts_db_name_from_url(url: &Url) -> Option<String> {
     }
 }
 
-fn from_url_basic<S: Into<String>>(url_str: S) -> Result<(Opts, Vec<(String, String)>), UrlError> {
-    let url = Url::parse(&url_str.into())?;
+fn from_url_basic<S: AsRef<str>>(url_str: S) -> Result<(Opts, Vec<(String, String)>), UrlError> {
+    let url = Url::parse(url_str.as_ref())?;
     if url.scheme() != "mysql" {
         return Err(UrlError::UnsupportedScheme(url.scheme().to_string()));
     }
@@ -499,7 +499,7 @@ fn from_url_basic<S: Into<String>>(url_str: S) -> Result<(Opts, Vec<(String, Str
     Ok((opts, query_pairs))
 }
 
-fn from_url<S: Into<String>>(url: S) -> Result<Opts, UrlError> {
+fn from_url<S: AsRef<str>>(url: S) -> Result<Opts, UrlError> {
     let (mut opts, query_pairs) = from_url_basic(url)?;
     for (key, value) in query_pairs {
         if key == "prefer_socket" {

--- a/src/conn/pool.rs
+++ b/src/conn/pool.rs
@@ -607,7 +607,11 @@ mod test {
 
         #[test]
         fn get_opts_from_string() {
-            Pool::new(format!("mysql://{}:{}@{}:{}", super::USER, super::PASS, super::ADDR, super::PORT)).unwrap();
+            let pass: String = ::std::env::var("MYSQL_SERVER_PASS").unwrap_or(super::PASS.to_string());
+            let port: u16 = ::std::env::var("MYSQL_SERVER_PORT").ok()
+                                   .map(|my_port| my_port.parse().ok().unwrap_or(super::PORT))
+                                   .unwrap_or(super::PORT);
+            Pool::new(format!("mysql://{}:{}@{}:{}", super::USER, pass, super::ADDR, port)).unwrap();
         }
 
         #[test]

--- a/src/conn/pool.rs
+++ b/src/conn/pool.rs
@@ -607,7 +607,7 @@ mod test {
 
         #[test]
         fn get_opts_from_string() {
-            let pool = Pool::new(format!("mysql://{}:{}@{}:{}", USER, PASS, ADDR, PORT)).unwrap();
+            Pool::new(format!("mysql://{}:{}@{}:{}", super::USER, super::PASS, super::ADDR, super::PORT)).unwrap();
         }
 
         #[test]

--- a/src/conn/pool.rs
+++ b/src/conn/pool.rs
@@ -606,6 +606,11 @@ mod test {
         }
 
         #[test]
+        fn get_opts_from_string() {
+            let pool = Pool::new(format!("mysql://{}:{}@{}:{}", USER, PASS, ADDR, PORT)).unwrap();
+        }
+
+        #[test]
         fn should_fix_connectivity_errors_on_prepare() {
             let pool = Pool::new_manual(2, 2, get_opts()).unwrap();
             let mut conn = pool.get_conn().unwrap();


### PR DESCRIPTION
This PR implements `From` for `Into<String>` on `Opts`, i.e. one can use either `&str` or `String` (or anything else that implements `Into<String>`) as argument type for `Pool::new`.
