### PR TITLE
feat: add get_opt and take_opt to row

### DIFF
--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -659,9 +659,9 @@ impl Row {
         })
     }
 
-    /// Will copy value at index `index` if it was not taken by `Row::take` earlier,
-    /// then will convert it to `T`. Returns `None` if the value was taken taken by
-    /// `Row::take` or was not able to be converted to `T`.
+    /// Will copy value at index `index` if it was not taken by `Row::take` or `Row::take_opt`
+    /// earlier, then will attempt convert it to `T`. Unlike `Row::get`, `Row::get_opt` will
+    /// allow you to directly handle errors if the value could not be converted to `T`.
     pub fn get_opt<T, I>(&mut self, index: I) -> Option<MyResult<T>>
     where T: FromValue,
           I: ColumnIndex {
@@ -682,8 +682,8 @@ impl Row {
     }
 
     /// Will take value of a column with index `index` if it exists and wasn't taken earlier then
-    /// will converts it to `T`. Returns `None` if the value was taken earlier or was not able
-    /// to be converted to `T`.
+    /// will attempt to convert it to `T`. Unlike `Row::take`, `Row::take_opt` will allow you to
+    /// directly handle errors if the value could not be converted to `T`.
     pub fn take_opt<T, I>(&mut self, index: I) -> Option<MyResult<T>>
     where T: FromValue,
           I: ColumnIndex {

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -659,6 +659,18 @@ impl Row {
         })
     }
 
+    /// Will copy value at index `index` if it was not taken by `Row::take` earlier,
+    /// then will convert it to `T`. Returns `None` if the value was taken taken by
+    /// `Row::take` or was not able to be converted to `T`.
+    pub fn get_opt<T, I>(&mut self, index: I) -> Option<T>
+    where T: FromValue,
+          I: ColumnIndex {
+        index.idx(&*self.columns)
+             .and_then(|idx| self.values.get(idx))
+             .and_then(|x| x.as_ref())
+             .and_then(|x| from_value_opt::<T>(x.clone()).ok())
+    }
+
     /// Will take value of a column with index `index` if it exists and wasn't taken earlier then
     /// will converts it to `T`.
     pub fn take<T, I>(&mut self, index: I) -> Option<T>
@@ -667,6 +679,18 @@ impl Row {
         index.idx(&*self.columns).and_then(|idx| {
             self.values.get_mut(idx).and_then(|x| x.take()).map(from_value::<T>)
         })
+    }
+
+    /// Will take value of a column with index `index` if it exists and wasn't taken earlier then
+    /// will converts it to `T`. Returns `None` if the value was taken earlier or was not able
+    /// to be converted to `T`.
+    pub fn take_opt<T, I>(&mut self, index: I) -> Option<T>
+    where T: FromValue,
+          I: ColumnIndex {
+        index.idx(&*self.columns)
+             .and_then(|idx| self.values.get_mut(idx))
+             .and_then(|x| x.take())
+             .and_then(|x| from_value_opt::<T>(x).ok())
     }
 
     /// Unwraps values of a row.

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -662,13 +662,13 @@ impl Row {
     /// Will copy value at index `index` if it was not taken by `Row::take` earlier,
     /// then will convert it to `T`. Returns `None` if the value was taken taken by
     /// `Row::take` or was not able to be converted to `T`.
-    pub fn get_opt<T, I>(&mut self, index: I) -> Option<T>
+    pub fn get_opt<T, I>(&mut self, index: I) -> Option<MyResult<T>>
     where T: FromValue,
           I: ColumnIndex {
         index.idx(&*self.columns)
              .and_then(|idx| self.values.get(idx))
              .and_then(|x| x.as_ref())
-             .and_then(|x| from_value_opt::<T>(x.clone()).ok())
+             .and_then(|x| Some(from_value_opt::<T>(x.clone())))
     }
 
     /// Will take value of a column with index `index` if it exists and wasn't taken earlier then
@@ -684,13 +684,13 @@ impl Row {
     /// Will take value of a column with index `index` if it exists and wasn't taken earlier then
     /// will converts it to `T`. Returns `None` if the value was taken earlier or was not able
     /// to be converted to `T`.
-    pub fn take_opt<T, I>(&mut self, index: I) -> Option<T>
+    pub fn take_opt<T, I>(&mut self, index: I) -> Option<MyResult<T>>
     where T: FromValue,
           I: ColumnIndex {
         index.idx(&*self.columns)
              .and_then(|idx| self.values.get_mut(idx))
              .and_then(|x| x.take())
-             .and_then(|x| from_value_opt::<T>(x).ok())
+             .and_then(|x| Some(from_value_opt::<T>(x)))
     }
 
     /// Unwraps values of a row.


### PR DESCRIPTION
It's useful to have a non-panicking way to get column values from a row. Nullable columns seem to fail with the traditional `.{get|take}` methods.