### PR TITLE
Add a link to page describing JSON type in MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ features = ["ssl"]
 
 ### JSON Support
 
-rust-mysql-simple offers JSON support based on *serde*, but you can switch to *rustc-serialize* using `rustc-serialize`
-feature:
+rust-mysql-simple offers [JSON](https://dev.mysql.com/doc/refman/5.7/en/json.html) support
+based on *serde*, but you can switch to *rustc-serialize* using `rustc-serialize` feature:
 
 ```toml
 [dependencies.mysql]


### PR DESCRIPTION
I added a link to the page describing the JSON type in MySQL in the section "JSON Support" based on the reply to my question in #117.