### PR TITLE
Support client compress

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ net2 = "~0.2"
 smallvec = "0.4"
 serde = "1"
 serde_json = "1"
-mysql_common = { git = "https://github.com/fiag/rust_mysql_common", optional = true }
+mysql_common = { version = "0.4", optional = true }
 
 [dependencies.rustc-serialize]
 version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ net2 = "~0.2"
 smallvec = "0.4"
 serde = "1"
 serde_json = "1"
-mysql_common = { version = "0.4", optional = true }
+mysql_common = { git = "https://github.com/fiag/rust_mysql_common", optional = true }
 
 [dependencies.rustc-serialize]
 version = "0.3"

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -849,6 +849,9 @@ impl Conn {
                 client_flags.insert(CapabilityFlags::CLIENT_SSL);
             }
         }
+        if self.opts.get_compress() {
+            client_flags.insert(CapabilityFlags::CLIENT_COMPRESS);
+        }
         client_flags
     }
 


### PR DESCRIPTION
to support 'mysql://localhost/foo?compress=true'

enables [compression](https://dev.mysql.com/doc/connector-net/en/connector-net-connection-options.html) of packets exchanged between the client and the server. 