### PR TITLE
Add option to use TCP_NODELAY (on by default)

### DIFF
--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -722,6 +722,7 @@ impl Conn {
         let read_timeout = self.opts.get_read_timeout().clone();
         let write_timeout = self.opts.get_write_timeout().clone();
         let tcp_keepalive_time = self.opts.get_tcp_keepalive_time_ms().clone();
+        let tcp_nodelay = self.opts.get_tcp_nodelay();
         let tcp_connect_timeout = self.opts.get_tcp_connect_timeout();
         let bind_address = self.opts.bind_address().cloned();
         let stream = if let Some(ref socket) = *self.opts.get_socket() {
@@ -733,6 +734,7 @@ impl Conn {
                                 read_timeout,
                                 write_timeout,
                                 tcp_keepalive_time,
+                                tcp_nodelay,
                                 tcp_connect_timeout,
                                 bind_address)?
         } else {

--- a/src/conn/opts.rs
+++ b/src/conn/opts.rs
@@ -64,6 +64,12 @@ pub struct Opts {
     /// connection to `127.0.0.1` if `true`.
     prefer_socket: bool,
 
+    /// Whether to enable `TCP_NODELAY` (defaults to `true`).
+    ///
+    /// This option disables Nagle's algorithm, which can cause unusually high latency (~40ms) at
+    /// some cost to maximum throughput. See #132.
+    tcp_nodelay: bool,
+
     /// TCP keep alive time for mysql connection.
     tcp_keepalive_time: Option<u32>,
 
@@ -195,6 +201,11 @@ impl Opts {
         self.verify_peer = val;
     }
 
+    /// Whether `TCP_NODELAY` will be set for mysql connection.
+    pub fn get_tcp_nodelay(&self) -> bool {
+        self.tcp_nodelay
+    }
+
     /// TCP keep alive time for mysql connection.
     pub fn get_tcp_keepalive_time_ms(&self) -> Option<u32> {
         self.tcp_keepalive_time
@@ -240,6 +251,7 @@ impl Default for Opts {
             verify_peer: false,
             ssl_opts: None,
             tcp_keepalive_time: None,
+            tcp_nodelay: true,
             local_infile_handler: None,
             tcp_connect_timeout: None,
             bind_address: None,
@@ -335,6 +347,15 @@ impl OptsBuilder {
     /// `tcp_keepalive_time_ms` url parameter.
     pub fn tcp_keepalive_time_ms(&mut self, tcp_keepalive_time_ms: Option<u32>) -> &mut Self {
         self.opts.tcp_keepalive_time = tcp_keepalive_time_ms;
+        self
+    }
+
+    /// Set the `TCP_NODELAY` option for the mysql connection (defaults to `true`).
+    ///
+    /// Setting this option to false re-enables Nagle's algorithm, which can cause unusually high
+    /// latency (~40ms) but may increase maximum throughput. See #132.
+    pub fn tcp_nodelay(&mut self, nodelay: bool) -> &mut Self {
+        self.opts.tcp_nodelay = nodelay;
         self
     }
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -384,6 +384,7 @@ impl Stream {
                        read_timeout: Option<Duration>,
                        write_timeout: Option<Duration>,
                        tcp_keepalive_time: Option<u32>,
+                       nodelay: bool,
                        tcp_connect_timeout: Option<Duration>,
                        bind_address: Option<SocketAddr>) -> MyResult<Stream>
     {
@@ -393,6 +394,7 @@ impl Stream {
             .read_timeout(read_timeout)
             .write_timeout(write_timeout)
             .keepalive_time_ms(tcp_keepalive_time)
+            .nodelay(nodelay)
             .bind_address(bind_address);
         builder.connect()
             .map(|stream| Stream::TcpStream(Some(TcpStream::Insecure(BufStream::new(stream)))))

--- a/src/io/tcp.rs
+++ b/src/io/tcp.rs
@@ -31,11 +31,17 @@ pub struct MyTcpBuilder<T> {
     read_timeout: Option<Duration>,
     write_timeout: Option<Duration>,
     keepalive_time_ms: Option<u32>,
+    nodelay: bool,
 }
 
 impl<T: ToSocketAddrs> MyTcpBuilder<T> {
     pub fn keepalive_time_ms(&mut self, keepalive_time_ms: Option<u32>) -> &mut Self {
         self.keepalive_time_ms = keepalive_time_ms;
+        self
+    }
+
+    pub fn nodelay(&mut self, nodelay: bool) -> &mut Self {
+        self.nodelay = nodelay;
         self
     }
 
@@ -69,6 +75,7 @@ impl<T: ToSocketAddrs> MyTcpBuilder<T> {
             read_timeout: None,
             write_timeout: None,
             keepalive_time_ms: None,
+            nodelay: true,
         }
     }
 
@@ -80,6 +87,7 @@ impl<T: ToSocketAddrs> MyTcpBuilder<T> {
             read_timeout,
             write_timeout,
             keepalive_time_ms,
+            nodelay,
         } = self;
         let err_msg = if bind_address.is_none() {
             "could not connect to any address"
@@ -115,6 +123,7 @@ impl<T: ToSocketAddrs> MyTcpBuilder<T> {
                 stream.set_read_timeout(read_timeout)?;
                 stream.set_write_timeout(write_timeout)?;
                 stream.set_keepalive_ms(keepalive_time_ms)?;
+                stream.set_nodelay(nodelay)?;
                 Ok(stream)
             })
     }


### PR DESCRIPTION
When a command (or part of a command) is much smaller than the network MTU, a (well-known) problem occurs between delayed ACKs and Nagle's algorithm. Specifically, Nagle tries to maximize packet size, and will avoid sending a non-full packet unless there are no currently unacked packets. Delayed ACKs delays sending ACKs to (again) minimize the number of packets sent over the network, and instead coalesce many ACKs over a prolonged period of time. When sending small messages, these interact poorly: Nagle will effectively not let you send a packet until the delayed ACK timeout expires on the other host.

The standard dictates that the delayed ACK timeout is at most 500ms, but in Linux, the actual delays are dictated by [`TCP_DELACK_MIN/MAX`](https://elixir.bootlin.com/linux/latest/ident/TCP_DELACK_MIN), and the minimum is usually set to 40ms. These 40ms will appear as an artificial delay to some commands, without the server or client doing any useful work.

This commit enables TCP_NODELAY by default, which turns off Nagle's algorithm. Applications that want to maximize throughput despite the latency cost can disable the option through the new `tcp_nodelay` method on `OptsBuilder`. Fixes #132.