### PR TITLE
add option to configure features of the dependency "flate2".

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,16 +41,19 @@ debug = false
 lto = true
 
 [features]
-default = ['mysql_common']
-nightly = ['mysql_common']
+default = ['mysql_common', 'flate2/default']
+nightly = ['mysql_common', 'flate2/default']
+flate2-zlib = ['mysql_common', 'flate2/zlib']
+flate2-rust_backend = ['mysql_common', 'flate2/rust_backend']
 rustc_serialize = ['mysql_common/rustc_serialize', 'rustc-serialize']
 ssl = ['mysql_common', "openssl", "security-framework"]
+
 
 [dev-dependencies]
 serde_derive = "1"
 
 [dependencies]
-flate2 = "1.0"
+flate2 = { version = "1.0", optional = true, default-features = false }
 bit-vec = "0.5"
 byteorder = "1"
 url = "1"

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ test:
 		cargo clean; \
 		sleep 15; \
 		echo TESTING FEATURS: $$var; \
-		if ! (cargo test --no-default-features --features "$$var"); \
+		if ! (cargo test --no-default-features --features "default $$var"); \
 		then \
 			kill -9 `cat $(MYSQL_DATA_DIR)/mysqld.pid`; \
 			rm -rf $(MYSQL_DATA_DIR) || true; \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,4 +56,4 @@ test_script:
 
     SET RUST_BACKTRACE=1
 
-    cargo test && cargo test --no-default-features --features rustc_serialize && cargo test --no-default-features --features ssl
+    cargo test && cargo test --no-default-features --features default rustc_serialize && cargo test --no-default-features --features default ssl


### PR DESCRIPTION
"flate2" uses "miniz-sys" as default (but exchangeable) backend which does not build for some targets (i686-unknown-linux-musl).

Flate2 documentation states that backends should be changed via features:
`flate2 = { version = "1.0", features = ["zlib"], default-features = false }`

The way flate2 is currently imported into mysql does not allow to change the flate2 features though. At least I don't know how that would be done.

With the PR applications can import mysql like this to enable different flate2 backends:
`mysql = { version = "*", features = ["flate2-zlib"], default-features = false }`

Mostly this change does not break the way mysql gets imported. There are two exceptions:
`mysql = { version = "*", features = ["ssl"], default-features = false }`
`mysql = { version = "*", features = ["rustc_serialize"], default-features = false }`

Both work without the PR, but fail to import flate2 with the PR. By disabling the default feature the user would have to add at least one of the "main" features: "default", "flate2-zlib" or "flate2-rust_backend". I think that makes sense though. 

Should there be an easier way to accomplish this, i'd be happy to learn about it.
