### PR TITLE
Add select_db(). Closes #170

### DIFF
--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -1503,8 +1503,8 @@ impl Conn {
         }
     }
 
-    /// Executes [`COM_INIT_DB`](https://dev.mysql.com/doc/internals/en/com-init-db.html) 
-    /// on `Conn`. 
+    /// Executes [`COM_INIT_DB`](https://dev.mysql.com/doc/internals/en/com-init-db.html)
+    /// on `Conn`.
     pub fn select_db(&mut self, schema: &str) -> bool {
         match self.write_command_data(Command::COM_INIT_DB, schema.as_bytes()) {
             Ok(_) => self.drop_packet().is_ok(),
@@ -2283,7 +2283,9 @@ mod test {
             opts.db_name(Some("mysql"));
             opts.ip_or_hostname(Some("localhost"));
             let mut conn = Conn::new(opts).unwrap();
-            assert!(conn.query("CREATE DATABASE IF NOT EXISTS t_select_db").is_ok());
+            assert!(conn
+                .query("CREATE DATABASE IF NOT EXISTS t_select_db")
+                .is_ok());
             assert!(conn.select_db("t_select_db"));
             assert_eq!(
                 conn.query("SELECT DATABASE()")

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -1503,6 +1503,15 @@ impl Conn {
         }
     }
 
+    /// Executes [`COM_INIT_DB`](https://dev.mysql.com/doc/internals/en/com-init-db.html) 
+    /// on `Conn`. 
+    pub fn select_db(&mut self, schema: &str) -> bool {
+        match self.write_command_data(Command::COM_INIT_DB, schema.as_bytes()) {
+            Ok(_) => self.drop_packet().is_ok(),
+            _ => false,
+        }
+    }
+
     /// Starts new transaction with provided options.
     /// `readonly` is only available since MySQL 5.6.5.
     pub fn start_transaction<'a>(
@@ -2267,6 +2276,25 @@ mod test {
                     .unwrap(),
                 vec![Bytes(b"mysql".to_vec())]
             );
+        }
+        #[test]
+        fn should_select_db() {
+            let mut opts = OptsBuilder::from_opts(get_opts());
+            opts.db_name(Some("mysql"));
+            opts.ip_or_hostname(Some("localhost"));
+            let mut conn = Conn::new(opts).unwrap();
+            assert!(conn.query("CREATE DATABASE IF NOT EXISTS t_select_db").is_ok());
+            assert!(conn.select_db("t_select_db"));
+            assert_eq!(
+                conn.query("SELECT DATABASE()")
+                    .unwrap()
+                    .next()
+                    .unwrap()
+                    .unwrap()
+                    .unwrap(),
+                vec![Bytes(b"t_select_db".to_vec())]
+            );
+            assert!(conn.query("DROP DATABASE t_select_db").is_ok());
         }
         #[test]
         fn should_execute_queryes_and_parse_results() {


### PR DESCRIPTION
The MySQL protocol defines COM_INIT_DB / 0x02 as "change the default schema of the connection" [1]. It is used by the MySQL CLI when doing a "USE db" statement and is implemented in the c client as:
 
    int mysql_select_db(MYSQL * mysql,
                         const char * db);

This pull request implements select_db(schema: &str) for mysql::Conn.

[1] https://dev.mysql.com/doc/internals/en/com-init-db.html