### PR TITLE
Thin statement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,4 +61,4 @@ winapi = "~0.3"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-nix = "0.15.0"
+nix = "0.17.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,23 +16,8 @@ build = "build.rs"
 name = "mysql"
 path = "src/lib.rs"
 
-[profile.dev]
-opt-level = 0
-debug = true
-
-[profile.release]
-opt-level = 3
-debug = false
-lto = true
-
-[profile.test]
-opt-level = 0
-debug = true
-
 [profile.bench]
 opt-level = 3
-debug = false
-lto = true
 
 [features]
 nightly = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,9 @@ serde_derive = "1"
 
 [dependencies]
 bufstream = "~0.1"
-fnv = "1"
 io-enum = "0.2.1"
-mysql_common = "0.19.2"
+lru = "0.4.3"
+mysql_common = "0.20.1"
 native-tls = "0.2.3"
 net2 = "~0.2"
 percent-encoding = "2.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "mysql"
 version = "17.0.0"
 authors = ["blackbeam"]
 description = "Mysql client library implemented in rust"
-license = "MIT"
+license = "MIT OR APACHE"
 documentation = "https://docs.rs/mysql"
 repository = "https://github.com/blackbeam/rust-mysql-simple"
 keywords = ["database", "sql"]
@@ -11,6 +11,10 @@ exclude = ["tests/*", ".*", "Makefile"]
 categories = ["database"]
 edition = "2018"
 build = "build.rs"
+
+[badges]
+appveyor = { repository = "blackbeam/rust-mysql-simple", branch = "master", service = "github" }
+travis-ci = { repository = "blackbeam/rust-mysql-simple", branch = "master" }
 
 [lib]
 name = "mysql"

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2015 Anatoly Ikorsky
+Copyright (c) 2020 rust-mysql-common contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ assert_eq!(val, Some(Value::Bytes("65536".as_bytes().to_vec())));
 
 ### Binary protocol and prepared statements.
 
-MySql binary protocol is implemented in `prep, `close` and the set of `exec*` methods,
+MySql binary protocol is implemented in `prep`, `close` and the set of `exec*` methods,
 defined on the [`Queryable`](#queryable) trait. Prepared statements is the only way to
 pass rust value to the MySql server. MySql uses `?` symbol as a parameter placeholder
 and it's only possible to use parameters where a single MySql value is expected.

--- a/README.md
+++ b/README.md
@@ -1,44 +1,615 @@
-rust-mysql-simple
-=================
-[![Build Status](https://travis-ci.org/blackbeam/rust-mysql-simple.png?branch=master)](https://travis-ci.org/blackbeam/rust-mysql-simple) [![Build status](https://ci.appveyor.com/api/projects/status/4te7c9q4tlmwvof0/branch/master?svg=true)](https://ci.appveyor.com/project/blackbeam/rust-mysql-simple/branch/master)
+[![Crates.io](https://img.shields.io/crates/v/mysql.svg)](https://crates.io/crates/mysql) [![Build Status](https://travis-ci.org/blackbeam/rust-mysql-simple.png?branch=master)](https://travis-ci.org/blackbeam/rust-mysql-simple) [![Build status](https://ci.appveyor.com/api/projects/status/4te7c9q4tlmwvof0/branch/master?svg=true)](https://ci.appveyor.com/project/blackbeam/rust-mysql-simple/branch/master)
 
-Mysql client library implemented in rust. Feel free to open new issues and pull requests.
+# mysql
 
-### Changelog
-Available [here](https://github.com/blackbeam/rust-mysql-simple/releases)
+This create offers:
 
-### Documentation
-Latest crate API docs are hosted on [docs.rs](https://docs.rs/crate/mysql).
+*   MySql database driver in pure rust;
+*   connection pool.
+
+Features:
+
+*   macOS, Windows and Linux support;
+*   TLS support via **nativetls** create;
+*   MySql text protocol support, i.e. support of simple text queries and text result sets;
+*   MySql binary protocol support, i.e. support of prepared statements and binary result sets;
+*   support of multi-result sets;
+*   support of named parameters for prepared statements;
+*   optional per-connection cache of prepared statements;
+*   support of MySql packets larger than 2^24;
+*   support of Unix sockets and Windows named pipes;
+*   support of custom LOCAL INFILE handlers;
+*   support of MySql protocol compression;
+*   support of auth plugins:
+    *   **mysql_native_password** - for MySql prior to v8;
+    *   **caching_sha2_password** - for MySql v8 and higher.
 
 ### Installation
-Please use [crates.io](https://crates.io/crates/mysql)
+
+Put the desired version of the crate into the `dependencies` section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
 mysql = "*"
 ```
 
-### SSL Support
+### Example
 
-rust-mysql-simple offers support for SSL via `ssl` cargo feature which is disabled by default.
-Add `ssl` feature to enable:
+```rust
+use mysql::*;
+use mysql::prelude::*;
 
-```toml
-[dependencies.mysql]
-version = "*"
-features = ["ssl"]
+#[derive(Debug, PartialEq, Eq)]
+struct Payment {
+    customer_id: i32,
+    amount: i32,
+    account_name: Option<String>,
+}
+
+let url = "mysql://root:password@localhost:3307/db_name";
+
+let pool = Pool::new(url)?;
+
+let mut conn = pool.get_conn()?;
+
+// Let's create a table for payments.
+conn.query_drop(
+    r"CREATE TEMPORARY TABLE payment (
+        customer_id int not null,
+        amount int not null,
+        account_name text
+    )")?;
+
+let payments = vec![
+    Payment { customer_id: 1, amount: 2, account_name: None },
+    Payment { customer_id: 3, amount: 4, account_name: Some("foo".into()) },
+    Payment { customer_id: 5, amount: 6, account_name: None },
+    Payment { customer_id: 7, amount: 8, account_name: None },
+    Payment { customer_id: 9, amount: 10, account_name: Some("bar".into()) },
+];
+
+// Now let's insert payments to the database
+conn.exec_batch(
+    r"INSERT INTO payment (customer_id, amount, account_name)
+      VALUES (:customer_id, :amount, :account_name)",
+    payments.iter().map(|p| params! {
+        "customer_id" => p.customer_id,
+        "amount" => p.amount,
+        "account_name" => &p.account_name,
+    })
+)?;
+
+// Let's select payments from database. Type inference should do the trick here.
+let selected_payments = conn
+    .query_map(
+        "SELECT customer_id, amount, account_name from payment",
+        |(customer_id, amount, account_name)| {
+            Payment { customer_id, amount, account_name }
+        },
+    )?;
+
+// Let's make sure, that `payments` equals to `selected_payments`.
+// Mysql gives no guaranties on order of returned rows
+// without `ORDER BY`, so assume we are lucky.
+assert_eq!(payments, selected_payments);
+println!("Yay!");
 ```
 
-### JSON Support
+### API Documentation
 
-rust-mysql-simple offers [JSON](https://dev.mysql.com/doc/refman/5.7/en/json.html) support
-based on *serde*, but you can switch to *rustc-serialize* using `rustc-serialize` feature:
+Please refer to the [crate docs].
 
-```toml
-[dependencies.mysql]
-version = "*"
-features = ["rustc-serialize"]
+### Basic structures
+
+#### `Opts`
+
+This structure holds server host name, client username/password and other settings,
+that controls client behavior.
+
+##### URL-based connection string
+
+Note, that you can use URL-based connection string as a source of an `Opts` instance.
+URL schema must be `mysql`. Host, port and credentials, as well as query parameters,
+should be given in accordance with the RFC 3986.
+
+Examples:
+
+```rust
+let _ = Opts::from_url("mysql://localhost/some_db")?;
+let _ = Opts::from_url("mysql://[::1]/some_db")?;
+let _ = Opts::from_url("mysql://user:pass%20word@127.0.0.1:3307/some_db?")?;
 ```
 
-### Windows support (since 0.18.0)
-Windows is supported but currently rust-mysql-simple has no support for SSL on Windows.
+Supported URL parameters (for the meaning of each field please refer to the docs on `Opts`
+structure in the create API docs):
+
+*   `prefer_socket: true | false` - defines the value of the same field in the `Opts` structure;
+*   `tcp_keepalive_time_ms: u32` - defines the value (in milliseconds)
+    of the `tcp_keepalive_time` field in the `Opts` structure;
+*   `tcp_connect_timeout_ms: u64` - defines the value (in milliseconds)
+    of the `tcp_connect_timeout` field in the `Opts` structure;
+*   `stmt_cache_size: u32` - defines the value of the same field in the `Opts` structure;
+*   `compress` - defines the value of the same field in the `Opts` structure.
+    Supported value are:
+    *  `true` - enables compression with the default compression level;
+    *  `fast` - enables compression with "fast" compression level;
+    *  `best` - enables compression with "best" compression level;
+    *  `1`..`9` - enables compression with the given compression level.
+*   `socket` - socket path on UNIX, or pipe name on Windows.
+
+#### `OptsBuilder`
+
+It's a convenient builder for the `Opts` structure. It defines setters for fields
+of the `Opts` structure.
+
+```rust
+let opts = OptsBuilder::new()
+    .user(Some("foo"))
+    .db_name(Some("bar"));
+let _ = Conn::new(opts)?;
+```
+
+#### `Conn`
+
+This structure represents an active MySql connection. It also holds statement cache
+and metadata for the last result set.
+
+#### `Transaction`
+
+It's a simple wrapper on top of a routine, that starts with `START TRANSACTION`
+and ends with `COMMIT` or `ROLBACK`.
+
+```rust
+use mysql::*;
+use mysql::prelude::*;
+
+let pool = Pool::new(get_opts())?;
+let mut conn = pool.get_conn()?;
+
+let mut tx = conn.start_transaction(false, None, None)?;
+tx.query_drop("CREATE TEMPORARY TABLE tmp (TEXT a)")?;
+tx.exec_drop("INSERT INTO tmp (a) VALUES (?)", ("foo",))?;
+let val: Option<String> = tx.query_first("SELECT a from tmp")?;
+assert_eq!(val.unwrap(), "foo");
+// Note, that transaction will be rolled back implicitly on Drop, if not committed.
+tx.rollback();
+
+let val: Option<String> = conn.query_first("SELECT a from tmp")?;
+assert_eq!(val, None);
+```
+
+#### `Pool`
+
+It's a reference to a connection pool, that can be cloned and shared between threads.
+
+```rust
+use mysql::*;
+use mysql::prelude::*;
+
+use std::thread::spawn;
+
+let pool = Pool::new(get_opts())?;
+
+let handles = (0..4).map(|i| {
+    spawn({
+        let pool = pool.clone();
+        move || {
+            let mut conn = pool.get_conn()?;
+            conn.exec_first::<u32, _, _>("SELECT ? * 10", (i,))
+                .map(Option::unwrap)
+        }
+    })
+});
+
+let result: Result<Vec<u32>> = handles.map(|handle| handle.join().unwrap()).collect();
+
+assert_eq!(result.unwrap(), vec![0, 10, 20, 30]);
+```
+
+#### `Statement`
+
+Statement, actually, is just an identifier coupled with statement metadata, i.e an information
+about its parameters and columns. Internally the `Statement` structure also holds additional
+data required to support named parameters (see bellow).
+
+```rust
+use mysql::*;
+use mysql::prelude::*;
+
+let pool = Pool::new(get_opts())?;
+let mut conn = pool.get_conn()?;
+
+let stmt = conn.prep("DO ?")?;
+
+// The prepared statement will return no columns.
+assert!(stmt.columns().is_empty());
+
+// The prepared statement have one parameter.
+let param = stmt.params().get(0).unwrap();
+assert_eq!(param.schema_str(), "");
+assert_eq!(param.table_str(), "");
+assert_eq!(param.name_str(), "?");
+```
+
+#### `Value`
+
+This enumeration represents the raw value of a MySql cell. Library offers conversion between
+`Value` and different rust types via `FromValue` trait described below.
+
+##### `FromValue` trait
+
+This trait is reexported from **mysql_common** create. Please refer to its
+[crate docs][mysql_common docs] for the list of supported conversions.
+
+Trait offers conversion in two flavours:
+
+*   `from_value(Value) -> T` - convenient, but panicking conversion.
+
+    Note, that for any variant of `Value` there exist a type, that fully covers its domain,
+    i.e. for any variant of `Value` there exist `T: FromValue` such that `from_value` will never
+    panic. This means, that if your database schema is known, than it's possible to write your
+    application using only `from_value` with no fear of runtime panic.
+
+*   `from_value_opt(Value) -> Option<T>` - non-panicking, but less convenient conversion.
+
+    This function is useful to probe conversion in cases, where source database schema
+    is unknown.
+
+```rust
+use mysql::*;
+use mysql::prelude::*;
+
+let via_test_protocol: u32 = from_value(Value::Bytes(b"65536".to_vec()));
+let via_bin_protocol: u32 = from_value(Value::UInt(65536));
+assert_eq!(via_test_protocol, via_bin_protocol);
+
+let unknown_val = // ...
+
+// Maybe it is a float?
+let unknown_val = match from_value_opt::<f64>(unknown_val) {
+    Ok(float) => {
+        println!("A float value: {}", float);
+        return Ok(());
+    }
+    Err(FromValueError(unknown_val)) => unknown_val,
+};
+
+// Or a string?
+let unknown_val = match from_value_opt::<String>(unknown_val) {
+    Ok(string) => {
+        println!("A string value: {}", string);
+        return Ok(());
+    }
+    Err(FromValueError(unknown_val)) => unknown_val,
+};
+
+// Screw this, I'll simply match on it
+match unknown_val {
+    val @ Value::NULL => {
+        println!("An empty value: {:?}", from_value::<Option<u8>>(val))
+    },
+    val @ Value::Bytes(..) => {
+        // It's non-utf8 bytes, since we already tried to convert it to String
+        println!("Bytes: {:?}", from_value::<Vec<u8>>(val))
+    }
+    val @ Value::Int(..) => {
+        println!("A signed integer: {}", from_value::<i64>(val))
+    }
+    val @ Value::UInt(..) => {
+        println!("An unsigned integer: {}", from_value::<u64>(val))
+    }
+    Value::Float(..) => unreachable!("already tried"),
+    val @ Value::Date(..) => {
+        use mysql::chrono::NaiveDateTime;
+        println!("A date value: {}", from_value::<NaiveDateTime>(val))
+    }
+    val @ Value::Time(..) => {
+        use std::time::Duration;
+        println!("A time value: {:?}", from_value::<Duration>(val))
+    }
+}
+```
+
+#### `Row`
+
+Internally `Row` is a vector of `Value`s, that also allows indexing by a column name/offset,
+and stores row metadata. Library offers conversion between `Row` and sequences of Rust types
+via `FromRow` trait described below.
+
+##### `FromRow` trait
+
+This trait is reexported from **mysql_common** create. Please refer to its
+[crate docs][mysql_common docs] for the list of supported conversions.
+
+This conversion is based on the `FromValue` and so comes in two similar flavours:
+
+*   `from_row(Row) -> T` - same as `from_value`, but for rows;
+*   `from_row_opt(Row) -> Option<T>` - same as `from_value_opt`, but for rows.
+
+[`Queryable`][#queryable] trait offers implicit conversion for rows of a query result,
+that is based on this trait.
+
+```rust
+use mysql::*;
+use mysql::prelude::*;
+
+let mut conn = Conn::new(get_opts())?;
+
+// Single-column row can be converted to a singular value
+let val: Option<String> = conn.query_first("SELECT 'foo'")?;
+assert_eq!(val.unwrap(), "foo");
+
+// Example of a mutli-column row conversion to an inferred type.
+let row = conn.query_first("SELECT 255, 256")?;
+assert_eq!(row, Some((255u8, 256u16)));
+
+// Some unknown row
+let row: Row = conn.query_first(
+    // ...
+    # "SELECT 255, Null",
+)?.unwrap();
+
+for column in row.columns_ref() {
+    let column_value = &row[column.name_str().as_ref()];
+    println!(
+        "Column {} of type {:?} with value {:?}",
+        column.name_str(),
+        column.column_type(),
+        column_value,
+    );
+}
+```
+
+
+#### `Params`
+
+Represents parameters of a prepared statement, but this type won't appear directly in your code
+because binary protocol API will ask for `T: Into<Params>`, where `Into<Params>` is implemented:
+
+*   for tuples of `Into<Value>` types up to arity 12;
+
+    **Note:** singular tuple requires extra comma, e.g. `("foo",)`;
+
+*   for `IntoIterator<Item: Into<Value>>` for cases, when your statement takes more
+    than 12 parameters;
+*   for named parameters representation (the value of the `params!` macro, described below).
+
+```rust
+use mysql::*;
+use mysql::prelude::*;
+
+let mut conn = Conn::new(get_opts())?;
+
+// Singular tuple requires extra comma:
+let row: Option<u8> = conn.exec_first("SELECT ?", (0,))?;
+assert_eq!(row.unwrap(), 0);
+
+// More than 12 parameters:
+let row: Option<u8> = conn.exec_first(
+    "SELECT ? + ? + ? + ? + ? + ? + ? + ? + ? + ? + ? + ? + ? + ? + ? + ?",
+    (0..16).collect::<Vec<_>>(),
+)?;
+assert_eq!(row.unwrap(), 120);
+```
+
+**Note:** Please refer to the [**mysql_common** crate docs][mysql_common docs] for the list
+of types, that implements `Into<Value>`.
+
+##### `Serialized`, `Deserialized`
+
+Wrapper structures for cases, when you need to provide a value for a JSON cell,
+or when you need to parse JSON cell as a struct.
+
+```rust
+use mysql::*;
+use mysql::prelude::*;
+
+/// Serializable structure.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Example {
+    foo: u32,
+}
+
+// Value::from for Serialized will emit json string.
+let value = Value::from(Serialized(Example { foo: 42 }));
+assert_eq!(value, Value::Bytes(br#"{"foo":42}"#.to_vec()));
+
+// from_value for Deserialized will parse json string.
+let structure: Deserialized<Example> = from_value(value);
+assert_eq!(structure, Deserialized(Example { foo: 42 }));
+```
+
+#### `QueryResult`
+
+It's an iterator over rows of a query result with support of multi-result sets. It's intended
+for cases when you need full control during result set iteration. For other cases `Conn`
+provides a set of methods that will immediately consume the first result set and drop everything
+else.
+
+This iterator is lazy so it won't read the result from server until you iterate over it.
+MySql protocol is strictly sequential, so `Conn` will be mutably borrowed until the result
+is fully consumed.
+
+```rust
+use mysql::*;
+use mysql::prelude::*;
+
+let mut conn = Conn::new(get_opts())?;
+
+// This query will emit two result sets.
+let mut result = conn.query_iter("SELECT 1, 2; SELECT 3, 3.14;")?;
+
+let mut set = 0;
+while result.more_results_exists() {
+    println!("Result set columns: {:?}", result.columns_ref());
+
+    for row in result.by_ref() {
+        match set {
+            0 => {
+                // First result set will contain two numbers.
+                assert_eq!((1_u8, 2_u8), from_row(row?));
+            }
+            1 => {
+                // Second result set will contain a number and a float.
+                assert_eq!((3_u8, 3.14), from_row(row?));
+            }
+            _ => unreachable!(),
+        }
+    }
+    set += 1;
+}
+```
+
+### Text protocol
+
+MySql text protocol is implemented in the set of `Conn::query*` methods. It's useful when your
+query doesn't have parameters.
+
+**Note:** All values of a text protocol result set will be encoded as strings by the server,
+so `from_value` conversion may lead to additional parsing costs.
+
+Examples:
+
+```rust
+let pool = Pool::new(get_opts())?;
+let val = pool.get_conn()?.query_first("SELECT POW(2, 16)")?;
+
+// Text protocol returns bytes even though the result of POW
+// is actually a floating point number.
+assert_eq!(val, Some(Value::Bytes("65536".as_bytes().to_vec())));
+```
+
+### Binary protocol and prepared statements.
+
+MySql binary protocol is implemented in `prep, `close` and the set of `exec*` methods,
+defined on the [`Queryable`](#queryable) trait. Prepared statements is the only way to
+pass rust value to the MySql server. MySql uses `?` symbol as a parameter placeholder
+and it's only possible to use parameters where a single MySql value is expected.
+For example:
+
+```rust
+let pool = Pool::new(get_opts())?;
+let val = pool.get_conn()?.exec_first("SELECT POW(?, ?)", (2, 16))?;
+
+assert_eq!(val, Some(Value::Float(65536.0)));
+```
+
+#### Statements
+
+In MySql each prepared statement belongs to a particular connection and can't be executed
+on another connection. Trying to do so will lead to an error. The driver won't tie statement
+to a connection in any way, but one can look on to the connection id, that is stored
+in the `Statement` structure.
+
+```rust
+let pool = Pool::new(get_opts())?;
+
+let mut conn_1 = pool.get_conn()?;
+let mut conn_2 = pool.get_conn()?;
+
+let stmt_1 = conn_1.prep("SELECT ?")?;
+
+// stmt_1 is for the conn_1, ..
+assert!(stmt_1.connection_id() == conn_1.connection_id());
+assert!(stmt_1.connection_id() != conn_2.connection_id());
+
+// .. so stmt_1 will execute only on conn_1
+assert!(conn_1.exec_drop(&stmt_1, ("foo",)).is_ok());
+assert!(conn_2.exec_drop(&stmt_1, ("foo",)).is_err());
+```
+
+#### Statement cache
+
+`Conn` will manage the cache of prepared statements on the client side, so subsequent calls
+to prepare with the same statement won't lead to a client-server roundtrip. Cache size
+for each connection is determined by the `stmt_cache_size` field of the `Opts` structure.
+Statements, that are out of this boundary will be closed in LRU order.
+
+Statement cache is completely disabled if `stmt_cache_size` is zero.
+
+**Caveats:**
+
+*   disabled statement cache means, that you have to close statements yourself using
+    `Conn::close`, or they'll exhaust server limits/resources;
+
+*   you should be aware of the [`max_prepared_stmt_count`][max_prepared_stmt_count]
+    option of the MySql server. If the number of active connections times the value
+    of `stmt_cache_size` is greater, than you could receive an error while prepareing
+    another statement.
+
+#### Named parameters
+
+MySql itself doesn't have named parameters support, so it's implemented on the client side.
+One should use `:name` as a placeholder syntax for a named parameter.
+
+Named parameters may be repeated within the statement, e.g `SELECT :foo :foo` will require
+a single named parameter `foo` that will be repeated on the corresponding positions during
+statement execution.
+
+One should use the `params!` macro to build a parameters for execution.
+
+**Note:** Positional and named parameters can't be mixed within the single statement.
+
+Examples:
+
+```rust
+let pool = Pool::new(get_opts())?;
+
+let mut conn = pool.get_conn()?;
+let stmt = conn.prep("SELECT :foo, :bar, :foo")?;
+
+let foo = 42;
+
+let val_13 = conn.exec_first(&stmt, params! { "foo" => 13, "bar" => foo })?.unwrap();
+// Short syntax is available when param name is the same as variable name:
+let val_42 = conn.exec_first(&stmt, params! { foo, "bar" => 13 })?.unwrap();
+
+assert_eq!((foo, 13, foo), val_42);
+assert_eq!((13, foo, 13), val_13);
+```
+
+#### `Queryable`
+
+The `Queryable` trait defines common methods for `Conn`, `PooledConn` and `Transaction`.
+The set of basic methods consts of:
+
+*   `query_iter` - basic methods to execute text query and get `QueryRestul`;
+*   `prep` - basic method to prepare a statement;
+*   `exec_iter` - basic method to execute statement and get `QueryResult`;
+*   `close` - basic method to close the statement;
+
+The trait also defines the set of helper methods, that is based on basic methods.
+These methods will consume only the firt result set, other result sets will be dropped:
+
+*   `{query|exec}` - to collect the result into a `Vec<T: FromRow>`;
+*   `{query|exec}_first` - to get the first `T: FromRow`, if any;
+*   `{query|exec}_map` - to map each `T: FromRow` to some `U`;
+*   `{query|exec}_fold` - to fold the set of `T: FromRow` to a single value;
+*   `{query|exec}_drop` - to immediately drop the result.
+
+The trait also defines additional helper for a batch statement execution.
+
+[crate docs]: https://docs.rs/mysql
+[mysql_common docs]: https://docs.rs/mysql_common
+[max_prepared_stmt_count]: https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_prepared_stmt_count
+
+
+## Changelog
+
+Available [here](https://github.com/blackbeam/rust-mysql-simple/releases)
+
+## License
+
+Licensed under either of
+
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you, as defined in the Apache-2.0
+license, shall be dual licensed as above, without any additional terms or
+conditions.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![Crates.io](https://img.shields.io/crates/v/mysql.svg)](https://crates.io/crates/mysql) [![Build Status](https://travis-ci.org/blackbeam/rust-mysql-simple.png?branch=master)](https://travis-ci.org/blackbeam/rust-mysql-simple) [![Build status](https://ci.appveyor.com/api/projects/status/4te7c9q4tlmwvof0/branch/master?svg=true)](https://ci.appveyor.com/project/blackbeam/rust-mysql-simple/branch/master)
+[![Crates.io](https://img.shields.io/crates/v/mysql.svg)](https://crates.io/crates/mysql)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/blackbeam/rust-mysql-simple?branch=master&svg=true)](https://ci.appveyor.com/project/blackbeam/rust-mysql-simple/branch/master)
+[![Build Status](https://travis-ci.org/blackbeam/rust-mysql-simple.svg?branch=master)](https://travis-ci.org/blackbeam/rust-mysql-simple)
 
 # mysql
 

--- a/README.tpl
+++ b/README.tpl
@@ -1,0 +1,25 @@
+[![Crates.io](https://img.shields.io/crates/v/mysql.svg)](https://crates.io/crates/mysql) [![Build Status](https://travis-ci.org/blackbeam/rust-mysql-simple.png?branch=master)](https://travis-ci.org/blackbeam/rust-mysql-simple) [![Build status](https://ci.appveyor.com/api/projects/status/4te7c9q4tlmwvof0/branch/master?svg=true)](https://ci.appveyor.com/project/blackbeam/rust-mysql-simple/branch/master)
+
+# {{crate}}
+
+{{readme}}
+
+## Changelog
+
+Available [here](https://github.com/blackbeam/rust-mysql-simple/releases)
+
+## License
+
+Licensed under either of
+
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you, as defined in the Apache-2.0
+license, shall be dual licensed as above, without any additional terms or
+conditions.

--- a/README.tpl
+++ b/README.tpl
@@ -1,4 +1,5 @@
-[![Crates.io](https://img.shields.io/crates/v/mysql.svg)](https://crates.io/crates/mysql) [![Build Status](https://travis-ci.org/blackbeam/rust-mysql-simple.png?branch=master)](https://travis-ci.org/blackbeam/rust-mysql-simple) [![Build status](https://ci.appveyor.com/api/projects/status/4te7c9q4tlmwvof0/branch/master?svg=true)](https://ci.appveyor.com/project/blackbeam/rust-mysql-simple/branch/master)
+[![Crates.io](https://img.shields.io/crates/v/mysql.svg)](https://crates.io/crates/mysql)
+{{badges}}
 
 # {{crate}}
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,13 +22,13 @@ environment:
     PATH: C:\msys64\mingw64\bin\;c:\rust\bin;%PATH%
   - TARGET: beta-i686-pc-windows-gnu
     PATH: C:\msys64\mingw32\bin\;c:\rust\bin;%PATH%
-  - TARGET: 1.38.0-x86_64-pc-windows-msvc
+  - TARGET: 1.41.0-x86_64-pc-windows-msvc
     PATH: C:\msys64\mingw64\bin\;c:\rust\bin;%PATH%
-  - TARGET: 1.38.0-i686-pc-windows-msvc
+  - TARGET: 1.41.0-i686-pc-windows-msvc
     PATH: C:\msys64\mingw32\bin\;c:\rust\bin;%PATH%
-  - TARGET: 1.38.0-x86_64-pc-windows-gnu
+  - TARGET: 1.41.0-x86_64-pc-windows-gnu
     PATH: C:\msys64\mingw64\bin\;c:\rust\bin;%PATH%
-  - TARGET: 1.38.0-i686-pc-windows-gnu
+  - TARGET: 1.41.0-i686-pc-windows-gnu
     PATH: C:\msys64\mingw32\bin\;c:\rust\bin;%PATH%
     COMPRESS: 1
 services: mysql

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,11 @@
+// Copyright (c) 2020 rust-mysql-common contributors
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 use std::env;
 
 fn main() {

--- a/src/conn/local_infile.rs
+++ b/src/conn/local_infile.rs
@@ -1,3 +1,11 @@
+// Copyright (c) 2020 rust-mysql-common contributors
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 use std::{
     fmt, io,
     sync::{Arc, Mutex},

--- a/src/conn/local_infile.rs
+++ b/src/conn/local_infile.rs
@@ -1,5 +1,7 @@
-use std::sync::{Arc, Mutex};
-use std::{fmt, io};
+use std::{
+    fmt, io,
+    sync::{Arc, Mutex},
+};
 
 use crate::Conn;
 

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -1,3 +1,11 @@
+// Copyright (c) 2020 rust-mysql-common contributors
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 use mysql_common::{
     crypto,
     io::ReadMysqlExt,

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -981,7 +981,7 @@ mod test {
         where
             T: FromValue,
         {
-            conn.query_first::<_, (String, T)>(format!("show variables like '{}'", name))
+            conn.query_first::<(String, T), _>(format!("show variables like '{}'", name))
                 .unwrap()
                 .unwrap()
                 .1
@@ -1094,7 +1094,7 @@ mod test {
             assert_eq!(conn.last_insert_id(), 0);
 
             assert!(conn
-                .query_first::<_, TestRow>("SELECT * FROM mysql.tbl WHERE a = 'bar'")
+                .query_first::<TestRow, _>("SELECT * FROM mysql.tbl WHERE a = 'bar'")
                 .unwrap()
                 .is_none());
 
@@ -1344,14 +1344,14 @@ mod test {
             let stmt1 = conn.prep("SELECT :foo").unwrap();
             let stmt2 = conn.prep("SELECT :bar").unwrap();
             assert_eq!(
-                conn.exec::<_, _, String>(&stmt1, params! { "foo" => "foo" })
+                conn.exec::<String, _, _>(&stmt1, params! { "foo" => "foo" })
                     .unwrap(),
-                vec!["foo".to_string()],
+                vec![String::from("foo")],
             );
             assert_eq!(
-                conn.exec::<_, _, String>(&stmt2, params! { "bar" => "bar" })
+                conn.exec::<String, _, _>(&stmt2, params! { "bar" => "bar" })
                     .unwrap(),
-                vec!["bar".to_string()],
+                vec![String::from("bar")],
             );
         }
 
@@ -1474,7 +1474,7 @@ mod test {
             let mut conn = Conn::new(get_opts()).unwrap();
             let stmt = conn.prep("SELECT :a, :b, :a, :c, :d").unwrap();
             let result =
-                conn.exec_first::<_, _, crate::Row>(&stmt, params! {"a" => 1, "b" => 2, "c" => 3,});
+                conn.exec_first::<crate::Row, _, _>(&stmt, params! {"a" => 1, "b" => 2, "c" => 3,});
             match result {
                 Err(DriverError(MissingNamedParameter(ref x))) if x == "d" => (),
                 _ => assert!(false),

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -10,20 +10,24 @@ use mysql_common::packets::{
 use mysql_common::proto::{codec::Compression, sync_framed::MySyncFramed};
 use mysql_common::value::{read_bin_values, read_text_values, ServerSide};
 
-use std::borrow::Borrow;
-use std::collections::HashMap;
-use std::io::{self, Read, Write as _};
-use std::ops::{Deref, DerefMut};
-use std::{cmp, mem, process};
+use std::{
+    borrow::Borrow,
+    cmp,
+    collections::HashMap,
+    io::{self, Read, Write as _},
+    mem,
+    ops::{Deref, DerefMut},
+    process,
+    sync::Arc,
+};
 
 use crate::conn::local_infile::LocalInfile;
-use crate::conn::query_result::ResultConnRef;
-use crate::conn::stmt::InnerStmt;
+use crate::conn::stmt::{InnerStmt, Statement};
 use crate::conn::stmt_cache::StmtCache;
 use crate::conn::transaction::IsolationLevel;
 use crate::consts::{CapabilityFlags, Command, StatusFlags, MAX_PAYLOAD_LEN};
 use crate::io::Stream;
-use crate::prelude::FromRow;
+use crate::prelude::*;
 use crate::DriverError::{
     CouldNotConnect, MismatchedStmtParams, NamedParamsForPositionalQuery, Protocol41NotSet,
     ReadOnlyTransNotSupported, SetupError, TlsNotSupported, UnexpectedPacket, UnknownAuthPlugin,
@@ -32,8 +36,8 @@ use crate::DriverError::{
 use crate::Error::{DriverError, MySqlError};
 use crate::Value::{self, Bytes, NULL};
 use crate::{
-    from_row, from_value, from_value_opt, LocalInfileHandler, Opts, OptsBuilder, Params,
-    QueryResult, Result as MyResult, SslOpts, Stmt, Transaction,
+    from_value, from_value_opt, LocalInfileHandler, Opts, OptsBuilder, Params, QueryResult,
+    Result as MyResult, SslOpts, Transaction,
 };
 
 pub mod local_infile;
@@ -43,36 +47,6 @@ pub mod query_result;
 pub mod stmt;
 mod stmt_cache;
 pub mod transaction;
-
-/// A trait allowing abstraction over connections and transactions
-pub trait GenericConnection {
-    /// See
-    /// [`Conn#query`](struct.Conn.html#method.query).
-    fn query<T: AsRef<str>>(&mut self, query: T) -> MyResult<QueryResult<'_>>;
-
-    /// See
-    /// [`Conn#first`](struct.Conn.html#method.first).
-    fn first<T: AsRef<str>, U: FromRow>(&mut self, query: T) -> MyResult<Option<U>>;
-
-    /// See
-    /// [`Conn#prepare`](struct.Conn.html#method.prepare).
-    fn prepare<T: AsRef<str>>(&mut self, query: T) -> MyResult<Stmt<'_>>;
-
-    /// See
-    /// [`Conn#prep_exec`](struct.Conn.html#method.prep_exec).
-    fn prep_exec<A, T>(&mut self, query: A, params: T) -> MyResult<QueryResult<'_>>
-    where
-        A: AsRef<str>,
-        T: Into<Params>;
-
-    /// See
-    /// [`Conn#first_exec`](struct.Conn.html#method.first_exec).
-    fn first_exec<Q, P, T>(&mut self, query: Q, params: P) -> MyResult<Option<T>>
-    where
-        Q: AsRef<str>,
-        P: Into<Params>,
-        T: FromRow;
-}
 
 /// Mysql connection.
 #[derive(Debug)]
@@ -97,6 +71,21 @@ pub struct Conn {
 }
 
 impl Conn {
+    /// Returns connection identifier.
+    pub fn connection_id(&self) -> u32 {
+        self.connection_id
+    }
+
+    /// Returns number of rows affected by the last query.
+    pub fn affected_rows(&self) -> u64 {
+        self.affected_rows
+    }
+
+    /// Returns last insert id of the last query.
+    pub fn last_insert_id(&self) -> u64 {
+        self.last_insert_id
+    }
+
     fn stream_ref(&self) -> &MySyncFramed<Stream> {
         self.stream.as_ref().expect("incomplete connection")
     }
@@ -181,7 +170,7 @@ impl Conn {
             }
         };
         for cmd in conn.opts.get_init() {
-            conn.query(cmd)?;
+            conn.query_drop(cmd)?;
         }
         Ok(conn)
     }
@@ -580,7 +569,7 @@ impl Conn {
         self.write_command_raw(body)
     }
 
-    fn send_long_data(&mut self, stmt: &InnerStmt, params: &[Value]) -> MyResult<()> {
+    fn send_long_data(&mut self, stmt_id: u32, params: &[Value]) -> MyResult<()> {
         for (i, value) in params.into_iter().enumerate() {
             match value {
                 Bytes(bytes) => {
@@ -591,7 +580,7 @@ impl Conn {
                         None
                     });
                     for chunk in chunks {
-                        let com = ComStmtSendLongData::new(stmt.id(), i, chunk);
+                        let com = ComStmtSendLongData::new(stmt_id, i, chunk);
                         self.write_command_raw(com)?;
                     }
                 }
@@ -602,7 +591,7 @@ impl Conn {
         Ok(())
     }
 
-    fn _execute(&mut self, stmt: &InnerStmt, params: Params) -> MyResult<Vec<Column>> {
+    fn _execute(&mut self, stmt: &Statement, params: Params) -> MyResult<Vec<Column>> {
         let exec_request = match params {
             Params::Empty => {
                 if stmt.num_params() != 0 {
@@ -624,32 +613,21 @@ impl Conn {
                     ComStmtExecuteRequestBuilder::new(stmt.id()).build(&*params);
 
                 if as_long_data {
-                    self.send_long_data(stmt, &*params)?;
+                    self.send_long_data(stmt.id(), &*params)?;
                 }
 
                 body
             }
             Params::Named(_) => {
-                if stmt.named_params().is_none() {
+                if stmt.named_params.is_none() {
                     return Err(DriverError(NamedParamsForPositionalQuery));
                 }
-                let named_params = stmt.named_params().unwrap();
+                let named_params = stmt.named_params.as_ref().unwrap();
                 return self._execute(stmt, params.into_positional(named_params)?);
             }
         };
         self.write_command_raw(exec_request)?;
         self.handle_result_set()
-    }
-
-    fn execute<T: Into<Params>>(&mut self, stmt: &InnerStmt, params: T) -> MyResult<QueryResult> {
-        match self._execute(stmt, params.into()) {
-            Ok(columns) => Ok(QueryResult::new(
-                ResultConnRef::ViaConnRef(self),
-                columns,
-                true,
-            )),
-            Err(err) => Err(err),
-        }
     }
 
     fn _start_transaction(
@@ -659,7 +637,7 @@ impl Conn {
         readonly: Option<bool>,
     ) -> MyResult<()> {
         if let Some(i_level) = isolation_level {
-            let _ = self.query(format!("SET TRANSACTION ISOLATION LEVEL {}", i_level))?;
+            self.query_drop(format!("SET TRANSACTION ISOLATION LEVEL {}", i_level))?;
         }
         if let Some(readonly) = readonly {
             let supported = match (self.server_version, self.mariadb_server_version) {
@@ -670,16 +648,16 @@ impl Conn {
             if !supported {
                 return Err(DriverError(ReadOnlyTransNotSupported));
             }
-            let _ = if readonly {
-                self.query("SET TRANSACTION READ ONLY")?
+            if readonly {
+                self.query_drop("SET TRANSACTION READ ONLY")?;
             } else {
-                self.query("SET TRANSACTION READ WRITE")?
-            };
+                self.query_drop("SET TRANSACTION READ WRITE")?;
+            }
         }
-        let _ = if consistent_snapshot {
-            self.query("START TRANSACTION WITH CONSISTENT SNAPSHOT")?
+        if consistent_snapshot {
+            self.query_drop("START TRANSACTION WITH CONSISTENT SNAPSHOT")?;
         } else {
-            self.query("START TRANSACTION")?
+            self.query_drop("START TRANSACTION")?;
         };
         Ok(())
     }
@@ -786,47 +764,17 @@ impl Conn {
         Ok(Transaction::new(self))
     }
 
-    /// Implements text protocol of mysql server.
-    ///
-    /// Executes mysql query on `Conn`. [`QueryResult`](struct.QueryResult.html)
-    /// will borrow `Conn` until the end of its scope.
-    pub fn query<T: AsRef<str>>(&mut self, query: T) -> MyResult<QueryResult<'_>> {
-        match self._query(query.as_ref()) {
-            Ok(columns) => Ok(QueryResult::new(
-                ResultConnRef::ViaConnRef(self),
-                columns,
-                false,
-            )),
-            Err(err) => Err(err),
-        }
-    }
-
-    /// Performs query and returns first row.
-    pub fn first<T: AsRef<str>, U: FromRow>(&mut self, query: T) -> MyResult<Option<U>> {
-        self.query(query).and_then(|mut result| {
-            if let Some(row) = result.next() {
-                row.map(|x| Some(from_row(x)))
-            } else {
-                Ok(None)
-            }
-        })
-    }
-
-    fn _true_prepare(
-        &mut self,
-        query: &str,
-        named_params: Option<Vec<String>>,
-    ) -> MyResult<InnerStmt> {
+    fn _true_prepare(&mut self, query: &str) -> MyResult<InnerStmt> {
         self.write_command(Command::COM_STMT_PREPARE, query.as_bytes())?;
         let pld = self.read_packet()?;
-        let mut stmt = InnerStmt::from_payload(pld.as_ref(), named_params)?;
+        let mut stmt = InnerStmt::from_payload(pld.as_ref())?;
         if stmt.num_params() > 0 {
             let mut params: Vec<Column> = Vec::with_capacity(stmt.num_params() as usize);
             for _ in 0..stmt.num_params() {
                 let pld = self.read_packet()?;
                 params.push(column_from_payload(pld)?);
             }
-            stmt.set_params(Some(params));
+            stmt = stmt.with_params(Some(params));
             self.read_packet()?;
         }
         if stmt.num_columns() > 0 {
@@ -835,151 +783,27 @@ impl Conn {
                 let pld = self.read_packet()?;
                 columns.push(column_from_payload(pld)?);
             }
-            stmt.set_columns(Some(columns));
+            stmt = stmt.with_columns(Some(columns));
             self.read_packet()?;
         }
         Ok(stmt)
     }
 
-    fn _prepare(&mut self, query: &str, named_params: Option<Vec<String>>) -> MyResult<InnerStmt> {
-        if let Some(inner_st) = self.stmt_cache.get(query) {
-            let mut inner_st = inner_st.clone();
-            inner_st.set_named_params(named_params);
-            return Ok(inner_st);
+    fn _prepare(&mut self, query: &str) -> MyResult<Arc<InnerStmt>> {
+        if let Some(entry) = self.stmt_cache.by_query(query) {
+            return Ok(entry.stmt.clone());
         }
 
-        let inner_st = self._true_prepare(query, named_params)?;
+        let inner_st = Arc::new(self._true_prepare(query)?);
 
-        if self.stmt_cache.get_cap() > 0 {
-            if let Some(old_st) = self.stmt_cache.put(query.into(), inner_st.clone()) {
-                let com_stmt_close = ComStmtClose::new(old_st.id());
-                self.write_command_raw(com_stmt_close)?;
-            }
+        if let Some(old_stmt) = self
+            .stmt_cache
+            .put(Arc::new(query.into()), inner_st.clone())
+        {
+            self.close(Statement::new(old_stmt, None))?;
         }
 
         Ok(inner_st)
-    }
-
-    /// Implements binary protocol of mysql server.
-    ///
-    /// Prepares mysql statement on `Conn`. [`Stmt`](struct.Stmt.html) will
-    /// borrow `Conn` until the end of its scope.
-    ///
-    /// This call will take statement from cache if has been prepared on this connection.
-    ///
-    /// ### JSON caveats
-    ///
-    /// For the following statement you will get somewhat unexpected result `{"a": 0}`, because
-    /// booleans in mysql binary protocol is `TINYINT(1)` and will be interpreted as `0`:
-    ///
-    /// ```ignore
-    /// pool.prep_exec(r#"SELECT JSON_REPLACE('{"a": true}', '$.a', ?)"#, (false,));
-    /// ```
-    ///
-    /// You should wrap such parameters to a proper json value. For example:
-    ///
-    /// ```ignore
-    /// pool.prep_exec(r#"SELECT JSON_REPLACE('{"a": true}', '$.a', ?)"#, (Value::Bool(false),));
-    /// ```
-    ///
-    /// ### Named parameters support
-    ///
-    /// `prepare` supports named parameters in form of `:named_param_name`. Allowed characters for
-    /// parameter name is `[a-z_]`. Named parameters will be converted to positional before actual
-    /// call to prepare so `SELECT :a-:b, :a*:b` is actually `SELECT ?-?, ?*?`.
-    ///
-    /// ```
-    /// # #[macro_use] extern crate mysql; fn main() {
-    /// # use mysql::{Pool, Opts, OptsBuilder, from_row};
-    /// # use mysql::Error::DriverError;
-    /// # use mysql::DriverError::MixedParams;
-    /// # use mysql::DriverError::MissingNamedParameter;
-    /// # use mysql::DriverError::NamedParamsForPositionalQuery;
-    /// # fn get_opts() -> Opts {
-    /// #     let url = if let Ok(url) = std::env::var("DATABASE_URL") {
-    /// #         let opts = Opts::from_url(&url).expect("DATABASE_URL invalid");
-    /// #         if opts.get_db_name().expect("a database name is required").is_empty() {
-    /// #             panic!("database name is empty");
-    /// #         }
-    /// #         url
-    /// #     } else {
-    /// #         "mysql://root:password@127.0.0.1:3307/mysql".to_string()
-    /// #     };
-    /// #     Opts::from_url(&*url).unwrap()
-    /// # }
-    /// # let opts = get_opts();
-    /// # let pool = Pool::new(opts).unwrap();
-    /// // Names could be repeated
-    /// pool.prep_exec("SELECT :a+:b, :a * :b, ':c'", params!{"a" => 2, "b" => 3}).map(|mut result| {
-    ///     let row = result.next().unwrap().unwrap();
-    ///     assert_eq!((5, 6, String::from(":c")), from_row(row));
-    /// }).unwrap();
-    ///
-    /// // You can call named statement with positional parameters
-    /// pool.prep_exec("SELECT :a+:b, :a*:b", (2, 3, 2, 3)).map(|mut result| {
-    ///     let row = result.next().unwrap().unwrap();
-    ///     assert_eq!((5, 6), from_row(row));
-    /// }).unwrap();
-    ///
-    /// // You must pass all named parameters for statement
-    /// let err = pool.prep_exec("SELECT :name", params!{"another_name" => 42}).unwrap_err();
-    /// match err {
-    ///     DriverError(e) => {
-    ///         assert_eq!(MissingNamedParameter("name".into()), e);
-    ///     }
-    ///     _ => unreachable!(),
-    /// }
-    ///
-    /// // You can't call positional statement with named parameters
-    /// let err = pool.prep_exec("SELECT ?", params!{"first" => 42}).unwrap_err();
-    /// match err {
-    ///     DriverError(e) => assert_eq!(NamedParamsForPositionalQuery, e),
-    ///     _ => unreachable!(),
-    /// }
-    ///
-    /// // You can't mix named and positional parameters
-    /// let err = pool.prepare("SELECT :a, ?").unwrap_err();
-    /// match err {
-    ///     DriverError(e) => assert_eq!(MixedParams, e),
-    ///     _ => unreachable!(),
-    /// }
-    /// # }
-    /// ```
-    pub fn prepare<T: AsRef<str>>(&mut self, query: T) -> MyResult<Stmt<'_>> {
-        let query = query.as_ref();
-        let (named_params, real_query) = parse_named_params(query)?;
-        match self._prepare(real_query.borrow(), named_params) {
-            Ok(stmt) => Ok(Stmt::new(stmt, self)),
-            Err(err) => Err(err),
-        }
-    }
-
-    /// Prepares and executes statement in one call. See
-    /// ['Conn::prepare'](struct.Conn.html#method.prepare)
-    ///
-    /// This call will take statement from cache if has been prepared on this connection.
-    pub fn prep_exec<A, T>(&mut self, query: A, params: T) -> MyResult<QueryResult<'_>>
-    where
-        A: AsRef<str>,
-        T: Into<Params>,
-    {
-        self.prepare(query)?.prep_exec(params.into())
-    }
-
-    /// Executes statement and returns first row.
-    pub fn first_exec<Q, P, T>(&mut self, query: Q, params: P) -> MyResult<Option<T>>
-    where
-        Q: AsRef<str>,
-        P: Into<Params>,
-        T: FromRow,
-    {
-        self.prep_exec(query, params).and_then(|mut result| {
-            if let Some(row) = result.next() {
-                row.map(|x| Some(from_row(x)))
-            } else {
-                Ok(None)
-            }
-        })
     }
 
     fn connect(&mut self) -> MyResult<()> {
@@ -1005,14 +829,7 @@ impl Conn {
     }
 
     fn get_system_var(&mut self, name: &str) -> MyResult<Option<Value>> {
-        for row in self.query(format!("SELECT @@{}", name))? {
-            if let Ok(mut r) = row {
-                if r.len() > 0 {
-                    return Ok(r.take(0));
-                }
-            }
-        }
-        Ok(None)
+        self.query_first(format!("SELECT @@{}", name))
     }
 
     fn next_bin(&mut self, columns: &[Column]) -> MyResult<Option<Vec<Value>>> {
@@ -1046,7 +863,7 @@ impl Conn {
     }
 
     fn has_stmt(&self, query: &str) -> bool {
-        self.stmt_cache.contains(query)
+        self.stmt_cache.contains_query(query)
     }
 
     /// Sets a callback to handle requests for local files. These are
@@ -1065,43 +882,46 @@ impl Conn {
     }
 }
 
-impl GenericConnection for Conn {
-    fn query<T: AsRef<str>>(&mut self, query: T) -> MyResult<QueryResult<'_>> {
-        self.query(query)
+impl crate::prelude::Queryable for Conn {
+    fn query_iter<T: AsRef<str>>(&mut self, query: T) -> MyResult<QueryResult<'_>> {
+        match self._query(query.as_ref()) {
+            Ok(columns) => Ok(QueryResult::new(self, columns, false)),
+            Err(err) => Err(err),
+        }
     }
 
-    fn first<T: AsRef<str>, U: FromRow>(&mut self, query: T) -> MyResult<Option<U>> {
-        self.first(query)
+    fn prep<T: AsRef<str>>(&mut self, query: T) -> MyResult<Statement> {
+        let query = query.as_ref();
+        let (named_params, real_query) = parse_named_params(query)?;
+        self._prepare(real_query.borrow())
+            .map(|inner| Statement::new(inner, named_params))
     }
 
-    fn prepare<T: AsRef<str>>(&mut self, query: T) -> MyResult<Stmt<'_>> {
-        self.prepare(query)
+    fn close(&mut self, stmt: Statement) -> MyResult<()> {
+        let com_stmt_close = ComStmtClose::new(stmt.id());
+        self.write_command_raw(com_stmt_close)?;
+        Ok(())
     }
 
-    fn prep_exec<A, T>(&mut self, query: A, params: T) -> MyResult<QueryResult<'_>>
+    fn exec_iter<S, P>(&mut self, stmt: S, params: P) -> MyResult<QueryResult<'_>>
     where
-        A: AsRef<str>,
-        T: Into<Params>,
-    {
-        self.prep_exec(query, params)
-    }
-
-    fn first_exec<Q, P, T>(&mut self, query: Q, params: P) -> MyResult<Option<T>>
-    where
-        Q: AsRef<str>,
+        S: AsStatement,
         P: Into<Params>,
-        T: FromRow,
     {
-        self.first_exec(query, params)
+        let statement = stmt.as_statement(self)?;
+        let columns = self._execute(&*statement, params.into())?;
+        Ok(QueryResult::new(self, columns, true))
     }
 }
 
 impl Drop for Conn {
     fn drop(&mut self) {
         let stmt_cache = mem::replace(&mut self.stmt_cache, StmtCache::new(0));
-        for (_, inner_st) in stmt_cache.into_iter() {
-            let _ = self.write_command_raw(ComStmtClose::new(inner_st.id()));
+
+        for (_, entry) in stmt_cache.into_iter() {
+            let _ = self.close(Statement::new(entry.stmt, None));
         }
+
         if self.stream.is_some() {
             let _ = self.write_command(Command::COM_QUIT, &[]);
         }
@@ -1139,44 +959,38 @@ impl<'a> DerefMut for ConnRef<'a> {
 #[allow(non_snake_case)]
 mod test {
     mod my_conn {
-        use std::collections::HashMap;
-        use std::io::Write;
-        use std::{iter, process};
+        use std::{collections::HashMap, io::Write, iter, process};
 
-        use crate::prelude::{FromValue, ToValue};
-        use crate::test_misc::get_opts;
-        use crate::time::{now, Tm};
-        use crate::DriverError::{MissingNamedParameter, NamedParamsForPositionalQuery};
-        use crate::Error::DriverError;
-        use crate::Value::{Bytes, Date, Int, NULL};
         use crate::{
-            from_row, from_value, params, Conn, LocalInfileHandler, Opts, OptsBuilder, Params,
+            from_row, from_value, params,
+            prelude::*,
+            test_misc::get_opts,
+            time::Timespec,
+            Conn,
+            DriverError::{MissingNamedParameter, NamedParamsForPositionalQuery},
+            Error::DriverError,
+            LocalInfileHandler, Opts, OptsBuilder, Params,
+            Value::{self, Bytes, Date, Float, Int, NULL},
         };
 
         fn get_system_variable<T>(conn: &mut Conn, name: &str) -> T
         where
             T: FromValue,
         {
-            let row = conn
-                .first(format!("show variables like '{}'", name))
+            conn.query_first::<_, (String, T)>(format!("show variables like '{}'", name))
                 .unwrap()
-                .unwrap();
-            let (_, value): (String, T) = from_row(row);
-            value
+                .unwrap()
+                .1
         }
 
         #[test]
         fn should_connect() {
             let mut conn = Conn::new(get_opts()).unwrap();
-            let mode = conn
-                .query("SELECT @@GLOBAL.sql_mode")
+
+            let mode: String = conn
+                .query_first("SELECT @@GLOBAL.sql_mode")
                 .unwrap()
-                .next()
-                .unwrap()
-                .unwrap()
-                .take(0)
                 .unwrap();
-            let mode = from_value::<String>(mode);
             assert!(mode.contains("TRADITIONAL"));
             assert!(conn.ping());
 
@@ -1196,246 +1010,200 @@ mod test {
             opts.socket(Some("/foo/bar/baz"));
             let _ = Conn::new(opts).unwrap();
         }
+
         #[test]
         fn should_fallback_to_tcp_if_cant_switch_to_socket() {
             let mut opts = Opts::from(get_opts());
             opts.0.injected_socket = Some("/foo/bar/baz".into());
             let _ = Conn::new(opts).unwrap();
         }
+
         #[test]
         fn should_connect_with_database() {
+            const DB_NAME: &str = "mysql";
+
             let mut opts = OptsBuilder::from_opts(get_opts());
-            opts.db_name(Some("mysql"));
+            opts.db_name(Some(DB_NAME));
+
             let mut conn = Conn::new(opts).unwrap();
-            assert_eq!(
-                conn.query("SELECT DATABASE()")
-                    .unwrap()
-                    .next()
-                    .unwrap()
-                    .unwrap()
-                    .unwrap(),
-                vec![Bytes(b"mysql".to_vec())]
-            );
+
+            let db_name: String = conn.query_first("SELECT DATABASE()").unwrap().unwrap();
+            assert_eq!(db_name, DB_NAME);
         }
+
         #[test]
         fn should_connect_by_hostname() {
             let mut opts = OptsBuilder::from_opts(get_opts());
-            opts.db_name(Some("mysql"));
             opts.ip_or_hostname(Some("localhost"));
             let mut conn = Conn::new(opts).unwrap();
-            assert_eq!(
-                conn.query("SELECT DATABASE()")
-                    .unwrap()
-                    .next()
-                    .unwrap()
-                    .unwrap()
-                    .unwrap(),
-                vec![Bytes(b"mysql".to_vec())]
-            );
+            assert!(conn.ping());
         }
+
         #[test]
         fn should_select_db() {
-            let mut opts = OptsBuilder::from_opts(get_opts());
-            opts.db_name(Some("mysql"));
-            opts.ip_or_hostname(Some("localhost"));
-            let mut conn = Conn::new(opts).unwrap();
-            assert!(conn
-                .query("CREATE DATABASE IF NOT EXISTS t_select_db")
-                .is_ok());
-            assert!(conn.select_db("t_select_db"));
-            assert_eq!(
-                conn.query("SELECT DATABASE()")
-                    .unwrap()
-                    .next()
-                    .unwrap()
-                    .unwrap()
-                    .unwrap(),
-                vec![Bytes(b"t_select_db".to_vec())]
-            );
-            assert!(conn.query("DROP DATABASE t_select_db").is_ok());
+            const DB_NAME: &str = "t_select_db";
+
+            let mut conn = Conn::new(get_opts()).unwrap();
+            conn.query_drop(format!("CREATE DATABASE IF NOT EXISTS {}", DB_NAME))
+                .unwrap();
+            assert!(conn.select_db(DB_NAME));
+
+            let db_name: String = conn.query_first("SELECT DATABASE()").unwrap().unwrap();
+            assert_eq!(db_name, DB_NAME);
+
+            conn.query_drop(format!("DROP DATABASE {}", DB_NAME))
+                .unwrap();
         }
+
         #[test]
         fn should_execute_queryes_and_parse_results() {
+            type TestRow = (String, String, String, String, String, String);
+
+            const CREATE_QUERY: &str = r"CREATE TEMPORARY TABLE mysql.tbl
+                (id SERIAL, a TEXT, b INT, c INT UNSIGNED, d DATE, e FLOAT)";
+            const INSERT_QUERY_1: &str = r"INSERT
+                INTO mysql.tbl(a, b, c, d, e)
+                VALUES ('hello', -123, 123, '2014-05-05', 123.123)";
+            const INSERT_QUERY_2: &str = r"INSERT
+                INTO mysql.tbl(a, b, c, d, e)
+                VALUES ('world', -321, 321, '2014-06-06', 321.321)";
+
             let mut conn = Conn::new(get_opts()).unwrap();
+
+            conn.query_drop(CREATE_QUERY).unwrap();
+            assert_eq!(conn.affected_rows(), 0);
+            assert_eq!(conn.last_insert_id(), 0);
+
+            conn.query_drop(INSERT_QUERY_1).unwrap();
+            assert_eq!(conn.affected_rows(), 1);
+            assert_eq!(conn.last_insert_id(), 1);
+
+            conn.query_drop(INSERT_QUERY_2).unwrap();
+            assert_eq!(conn.affected_rows(), 1);
+            assert_eq!(conn.last_insert_id(), 2);
+
+            conn.query_drop("SELECT * FROM unexisted").unwrap_err();
+            conn.query_iter("SELECT * FROM mysql.tbl").unwrap(); // Drop::drop for QueryResult
+
+            conn.query_drop("UPDATE mysql.tbl SET a = 'foo'").unwrap();
+            assert_eq!(conn.affected_rows(), 2);
+            assert_eq!(conn.last_insert_id(), 0);
+
             assert!(conn
-                .query(
-                    "CREATE TEMPORARY TABLE mysql.tbl(\
-                                    a TEXT,\
-                                    b INT,\
-                                    c INT UNSIGNED,\
-                                    d DATE,\
-                                    e FLOAT
-                                )"
-                )
-                .is_ok());
-            assert!(conn
-                .query(
-                    "INSERT INTO mysql.tbl(a, b, c, d, e) VALUES (\
-                     'hello',\
-                     -123,\
-                     123,\
-                     '2014-05-05',\
-                     123.123\
-                     )"
-                )
-                .is_ok());
-            assert!(conn
-                .query(
-                    "INSERT INTO mysql.tbl(a, b, c, d, e) VALUES (\
-                     'world',\
-                     -321,\
-                     321,\
-                     '2014-06-06',\
-                     321.321\
-                     )"
-                )
-                .is_ok());
-            assert!(conn.query("SELECT * FROM unexisted").is_err());
-            assert!(conn.query("SELECT * FROM mysql.tbl").is_ok());
-            // Drop
-            assert!(conn.query("UPDATE mysql.tbl SET a = 'foo'").is_ok());
-            assert_eq!(conn.affected_rows, 2);
-            assert!(conn
-                .query("SELECT * FROM mysql.tbl WHERE a = 'bar'")
+                .query_first::<_, TestRow>("SELECT * FROM mysql.tbl WHERE a = 'bar'")
                 .unwrap()
-                .next()
                 .is_none());
-            for (i, row) in conn.query("SELECT * FROM mysql.tbl").unwrap().enumerate() {
-                let row = row.unwrap();
-                if i == 0 {
-                    assert_eq!(row[0], Bytes(b"foo".to_vec()));
-                    assert_eq!(row[1], Bytes(b"-123".to_vec()));
-                    assert_eq!(row[2], Bytes(b"123".to_vec()));
-                    assert_eq!(row[3], Bytes(b"2014-05-05".to_vec()));
-                    assert_eq!(row[4], Bytes(b"123.123".to_vec()));
-                } else if i == 1 {
-                    assert_eq!(row[0], Bytes(b"foo".to_vec()));
-                    assert_eq!(row[1], Bytes(b"-321".to_vec()));
-                    assert_eq!(row[2], Bytes(b"321".to_vec()));
-                    assert_eq!(row[3], Bytes(b"2014-06-06".to_vec()));
-                    assert_eq!(row[4], Bytes(b"321.321".to_vec()));
-                } else {
-                    unreachable!();
-                }
-            }
+
+            let rows: Vec<TestRow> = conn.query("SELECT * FROM mysql.tbl").unwrap();
+            assert_eq!(
+                rows,
+                vec![
+                    (
+                        "1".into(),
+                        "foo".into(),
+                        "-123".into(),
+                        "123".into(),
+                        "2014-05-05".into(),
+                        "123.123".into()
+                    ),
+                    (
+                        "2".into(),
+                        "foo".into(),
+                        "-321".into(),
+                        "321".into(),
+                        "2014-06-06".into(),
+                        "321.321".into()
+                    )
+                ]
+            );
         }
+
         #[test]
         fn should_parse_large_text_result() {
             let mut conn = Conn::new(get_opts()).unwrap();
-            assert_eq!(
-                conn.query("SELECT REPEAT('A', 20000000)")
-                    .unwrap()
-                    .next()
-                    .unwrap()
-                    .unwrap()
-                    .unwrap(),
-                vec![Bytes(iter::repeat(b'A').take(20_000_000).collect())]
-            );
+            let value: Value = conn
+                .query_first("SELECT REPEAT('A', 20000000)")
+                .unwrap()
+                .unwrap();
+            assert_eq!(value, Bytes(iter::repeat(b'A').take(20_000_000).collect()));
         }
+
         #[test]
         fn should_execute_statements_and_parse_results() {
+            const CREATE_QUERY: &str = r"CREATE TEMPORARY TABLE
+                mysql.tbl (a TEXT, b INT, c INT UNSIGNED, d DATE, e DOUBLE)";
+            const INSERT_SMTM: &str = r"INSERT
+                INTO mysql.tbl (a, b, c, d, e)
+                VALUES (?, ?, ?, ?, ?)";
+
+            type RowType = (Value, Value, Value, Value, Value);
+
+            let row1 = (
+                Bytes(b"hello".to_vec()),
+                Int(-123_i64),
+                Int(123_i64),
+                Date(2014_u16, 5_u8, 5_u8, 0_u8, 0_u8, 0_u8, 0_u32),
+                Float(123.123_f64),
+            );
+            let row2 = (Bytes(b"".to_vec()), NULL, NULL, NULL, Float(321.321_f64));
+
             let mut conn = Conn::new(get_opts()).unwrap();
-            assert!(conn
-                .query(
-                    "CREATE TEMPORARY TABLE mysql.tbl(\
-                     a TEXT,\
-                     b INT,\
-                     c INT UNSIGNED,\
-                     d DATE,\
-                     e DOUBLE\
-                     )"
-                )
-                .is_ok());
-            let _ = conn
-                .prepare(
-                    "INSERT INTO mysql.tbl(a, b, c, d, e)\
-                     VALUES (?, ?, ?, ?, ?)",
-                )
-                .and_then(|mut stmt| {
-                    let tm = Tm {
-                        tm_year: 114,
-                        tm_mon: 4,
-                        tm_mday: 5,
-                        tm_hour: 0,
-                        tm_min: 0,
-                        tm_sec: 0,
-                        tm_nsec: 0,
-                        ..now()
-                    };
-                    let hello = b"hello".to_vec();
-                    assert!(stmt
-                        .execute((&hello, -123, 123, tm.to_timespec(), 123.123f64))
-                        .is_ok());
-                    stmt.execute(
-                        &[
-                            &b"".to_vec() as &dyn ToValue,
-                            &NULL as &dyn ToValue,
-                            &NULL as &dyn ToValue,
-                            &NULL as &dyn ToValue,
-                            &321.321f64 as &dyn ToValue,
-                        ][..],
-                    )
-                    .unwrap();
-                    Ok(())
-                })
-                .unwrap();
-            let _ = conn
-                .prepare("SELECT * from mysql.tbl")
-                .and_then(|mut stmt| {
-                    for (i, row) in stmt.execute(()).unwrap().enumerate() {
-                        let mut row = row.unwrap();
-                        if i == 0 {
-                            assert_eq!(row[0], Bytes(b"hello".to_vec()));
-                            assert_eq!(row[1], Int(-123i64));
-                            assert_eq!(row[2], Int(123i64));
-                            assert_eq!(row[3], Date(2014u16, 5u8, 5u8, 0u8, 0u8, 0u8, 0u32));
-                            assert_eq!(row.take::<f64, _>(4).unwrap(), 123.123f64);
-                        } else if i == 1 {
-                            assert_eq!(row[0], Bytes(b"".to_vec()));
-                            assert_eq!(row[1], NULL);
-                            assert_eq!(row[2], NULL);
-                            assert_eq!(row[3], NULL);
-                            assert_eq!(row.take::<f64, _>(4).unwrap(), 321.321f64);
-                        } else {
-                            unreachable!();
-                        }
-                    }
-                    Ok(())
-                })
-                .unwrap();
-            let mut result = conn.prep_exec("SELECT ?, ?, ?", ("hello", 1, 1.1)).unwrap();
-            let row = result.next().unwrap();
-            let mut row = row.unwrap();
-            assert_eq!(row.take::<String, _>(0).unwrap(), "hello".to_string());
-            assert_eq!(row.take::<i8, _>(1).unwrap(), 1i8);
-            assert_eq!(row.take::<f32, _>(2).unwrap(), 1.1f32);
+            conn.query_drop(CREATE_QUERY).unwrap();
+
+            let insert_stmt = conn.prep(INSERT_SMTM).unwrap();
+            conn.exec_drop(
+                &insert_stmt,
+                (
+                    from_value::<String>(row1.0.clone()),
+                    from_value::<i32>(row1.1.clone()),
+                    from_value::<u32>(row1.2.clone()),
+                    from_value::<Timespec>(row1.3.clone()),
+                    from_value::<f64>(row1.4.clone()),
+                ),
+            )
+            .unwrap();
+            conn.exec_drop(
+                &insert_stmt,
+                (
+                    from_value::<String>(row2.0.clone()),
+                    row2.1.clone(),
+                    row2.2.clone(),
+                    row2.3.clone(),
+                    from_value::<f64>(row2.4.clone()),
+                ),
+            )
+            .unwrap();
+
+            let select_stmt = conn.prep("SELECT * from mysql.tbl").unwrap();
+            let rows: Vec<RowType> = conn.exec(&select_stmt, ()).unwrap();
+
+            assert_eq!(rows, vec![row1, row2]);
         }
+
         #[test]
         fn should_parse_large_binary_result() {
             let mut conn = Conn::new(get_opts()).unwrap();
-            let mut stmt = conn.prepare("SELECT REPEAT('A', 20000000);").unwrap();
-            assert_eq!(
-                stmt.execute(()).unwrap().next().unwrap().unwrap().unwrap(),
-                vec![Bytes(iter::repeat(b'A').take(20_000_000).collect())]
-            );
+            let stmt = conn.prep("SELECT REPEAT('A', 20000000)").unwrap();
+            let value: Value = conn.exec_first(&stmt, ()).unwrap().unwrap();
+            assert_eq!(value, Bytes(iter::repeat(b'A').take(20_000_000).collect()));
         }
+
         #[test]
         fn should_start_commit_and_rollback_transactions() {
             let mut conn = Conn::new(get_opts()).unwrap();
-            assert!(conn
-                .query("CREATE TEMPORARY TABLE mysql.tbl(a INT)")
-                .is_ok());
+            conn.query_drop("CREATE TEMPORARY TABLE mysql.tbl(a INT)")
+                .unwrap();
             let _ = conn
                 .start_transaction(false, None, None)
                 .and_then(|mut t| {
-                    assert!(t.query("INSERT INTO mysql.tbl(a) VALUES(1)").is_ok());
-                    assert!(t.query("INSERT INTO mysql.tbl(a) VALUES(2)").is_ok());
-                    assert!(t.commit().is_ok());
+                    t.query_drop("INSERT INTO mysql.tbl(a) VALUES(1)").unwrap();
+                    t.query_drop("INSERT INTO mysql.tbl(a) VALUES(2)").unwrap();
+                    t.commit().unwrap();
                     Ok(())
                 })
                 .unwrap();
             assert_eq!(
-                conn.query("SELECT COUNT(a) from mysql.tbl")
+                conn.query_iter("SELECT COUNT(a) from mysql.tbl")
                     .unwrap()
                     .next()
                     .unwrap()
@@ -1446,13 +1214,13 @@ mod test {
             let _ = conn
                 .start_transaction(false, None, None)
                 .and_then(|mut t| {
-                    t.query("INSERT INTO tbl2(a) VALUES(1)").unwrap_err();
+                    t.query_drop("INSERT INTO tbl2(a) VALUES(1)").unwrap_err();
                     Ok(())
                     // implicit rollback
                 })
                 .unwrap();
             assert_eq!(
-                conn.query("SELECT COUNT(a) from mysql.tbl")
+                conn.query_iter("SELECT COUNT(a) from mysql.tbl")
                     .unwrap()
                     .next()
                     .unwrap()
@@ -1463,14 +1231,14 @@ mod test {
             let _ = conn
                 .start_transaction(false, None, None)
                 .and_then(|mut t| {
-                    assert!(t.query("INSERT INTO mysql.tbl(a) VALUES(1)").is_ok());
-                    assert!(t.query("INSERT INTO mysql.tbl(a) VALUES(2)").is_ok());
-                    assert!(t.rollback().is_ok());
+                    t.query_drop("INSERT INTO mysql.tbl(a) VALUES(1)").unwrap();
+                    t.query_drop("INSERT INTO mysql.tbl(a) VALUES(2)").unwrap();
+                    t.rollback().unwrap();
                     Ok(())
                 })
                 .unwrap();
             assert_eq!(
-                conn.query("SELECT COUNT(a) from mysql.tbl")
+                conn.query_iter("SELECT COUNT(a) from mysql.tbl")
                     .unwrap()
                     .next()
                     .unwrap()
@@ -1478,23 +1246,14 @@ mod test {
                     .unwrap(),
                 vec![Bytes(b"2".to_vec())]
             );
-            let _ = conn
-                .start_transaction(false, None, None)
-                .and_then(|mut t| {
-                    let _ = t
-                        .prepare("INSERT INTO mysql.tbl(a) VALUES(?)")
-                        .and_then(|mut stmt| {
-                            assert!(stmt.execute((3,)).is_ok());
-                            assert!(stmt.execute((4,)).is_ok());
-                            Ok(())
-                        })
-                        .unwrap();
-                    assert!(t.commit().is_ok());
-                    Ok(())
-                })
+            let mut tx = conn.start_transaction(false, None, None).unwrap();
+            tx.exec_drop("INSERT INTO mysql.tbl(a) VALUES(?)", (3,))
                 .unwrap();
+            tx.exec_drop("INSERT INTO mysql.tbl(a) VALUES(?)", (4,))
+                .unwrap();
+            tx.commit().unwrap();
             assert_eq!(
-                conn.query("SELECT COUNT(a) from mysql.tbl")
+                conn.query_iter("SELECT COUNT(a) from mysql.tbl")
                     .unwrap()
                     .next()
                     .unwrap()
@@ -1502,21 +1261,21 @@ mod test {
                     .unwrap(),
                 vec![Bytes(b"4".to_vec())]
             );
-            let _ = conn
-                .start_transaction(false, None, None)
-                .and_then(|mut t| {
-                    t.prep_exec("INSERT INTO mysql.tbl(a) VALUES(?)", (5,))
-                        .unwrap();
-                    t.prep_exec("INSERT INTO mysql.tbl(a) VALUES(?)", (6,))
-                        .unwrap();
-                    Ok(())
-                })
+            let mut tx = conn.start_transaction(false, None, None).unwrap();
+            tx.exec_drop("INSERT INTO mysql.tbl(a) VALUES(?)", (5,))
                 .unwrap();
+            tx.exec_drop("INSERT INTO mysql.tbl(a) VALUES(?)", (6,))
+                .unwrap();
+            drop(tx);
+            assert_eq!(
+                conn.query_first("SELECT COUNT(a) from mysql.tbl").unwrap(),
+                Some(4_usize),
+            );
         }
         #[test]
         fn should_handle_LOCAL_INFILE_with_custom_handler() {
             let mut conn = Conn::new(get_opts()).unwrap();
-            conn.query("CREATE TEMPORARY TABLE mysql.tbl(a TEXT)")
+            conn.query_drop("CREATE TEMPORARY TABLE mysql.tbl(a TEXT)")
                 .unwrap();
             conn.set_local_infile_handler(Some(LocalInfileHandler::new(|_, stream| {
                 let mut cell_data = vec![b'Z'; 65535];
@@ -1526,7 +1285,7 @@ mod test {
                 }
                 Ok(())
             })));
-            match conn.query("LOAD DATA LOCAL INFILE 'file_name' INTO TABLE mysql.tbl") {
+            match conn.query_drop("LOAD DATA LOCAL INFILE 'file_name' INTO TABLE mysql.tbl") {
                 Ok(_) => {}
                 Err(ref err) if format!("{}", err).find("not allowed").is_some() => {
                     return;
@@ -1534,7 +1293,7 @@ mod test {
                 Err(err) => panic!("ERROR {}", err),
             }
             let count = conn
-                .query("SELECT * FROM mysql.tbl")
+                .query_iter("SELECT * FROM mysql.tbl")
                 .unwrap()
                 .map(|row| {
                     assert_eq!(from_row::<(Vec<u8>,)>(row.unwrap()).0.len(), 65535);
@@ -1547,15 +1306,33 @@ mod test {
         #[test]
         fn should_reset_connection() {
             let mut conn = Conn::new(get_opts()).unwrap();
-            assert!(conn
-                .query(
-                    "CREATE TEMPORARY TABLE `mysql`.`test` \
-                     (`test` VARCHAR(255) NULL);"
-                )
-                .is_ok());
-            assert!(conn.query("SELECT * FROM `mysql`.`test`;").is_ok());
-            assert!(conn.reset().is_ok());
-            assert!(conn.query("SELECT * FROM `mysql`.`test`;").is_err());
+            conn.query_drop(
+                "CREATE TEMPORARY TABLE `mysql`.`test` \
+                 (`test` VARCHAR(255) NULL);",
+            )
+            .unwrap();
+            conn.query_drop("SELECT * FROM `mysql`.`test`;").unwrap();
+            conn.reset().unwrap();
+            conn.query_drop("SELECT * FROM `mysql`.`test`;")
+                .unwrap_err();
+        }
+
+        #[test]
+        fn prep_exec() {
+            let mut conn = Conn::new(get_opts()).unwrap();
+
+            let stmt1 = conn.prep("SELECT :foo").unwrap();
+            let stmt2 = conn.prep("SELECT :bar").unwrap();
+            assert_eq!(
+                conn.exec::<_, _, String>(&stmt1, params! { "foo" => "foo" })
+                    .unwrap(),
+                vec!["foo".to_string()],
+            );
+            assert_eq!(
+                conn.exec::<_, _, String>(&stmt2, params! { "bar" => "bar" })
+                    .unwrap(),
+                vec!["bar".to_string()],
+            );
         }
 
         #[test]
@@ -1583,17 +1360,17 @@ mod test {
             let mut opts = OptsBuilder::from_opts(get_opts());
             opts.db_name(Some("mysql"));
             let mut conn = Conn::new(opts).unwrap();
-            conn.query("CREATE TEMPORARY TABLE TEST_TABLE ( name varchar(255) )")
+            conn.query_drop("CREATE TEMPORARY TABLE TEST_TABLE ( name varchar(255) )")
                 .unwrap();
-            conn.prep_exec("SELECT * FROM TEST_TABLE", ()).unwrap();
-            conn.query(
+            conn.exec_drop("SELECT * FROM TEST_TABLE", ()).unwrap();
+            conn.query_drop(
                 r"
                 INSERT INTO TEST_TABLE (name) VALUES ('one');
                 INSERT INTO TEST_TABLE (name) VALUES ('two');
                 INSERT INTO TEST_TABLE (name) VALUES ('three');",
             )
             .unwrap();
-            conn.prep_exec("SELECT * FROM TEST_TABLE", ()).unwrap();
+            conn.exec_drop("SELECT * FROM TEST_TABLE", ()).unwrap();
         }
 
         #[test]
@@ -1602,8 +1379,8 @@ mod test {
             opts.prefer_socket(false);
             opts.db_name(Some("mysql"));
             let mut conn = Conn::new(opts).unwrap();
-            conn.query("DROP PROCEDURE IF EXISTS multi").unwrap();
-            conn.query(
+            conn.query_drop("DROP PROCEDURE IF EXISTS multi").unwrap();
+            conn.query_drop(
                 r#"CREATE PROCEDURE multi() BEGIN
                         SELECT 1 UNION ALL SELECT 2;
                         DO 1;
@@ -1616,7 +1393,7 @@ mod test {
             )
             .unwrap();
             {
-                let mut query_result = conn.query("CALL multi()").unwrap();
+                let mut query_result = conn.query_iter("CALL multi()").unwrap();
                 let result_set = query_result
                     .by_ref()
                     .map(|row| row.unwrap().unwrap().pop().unwrap())
@@ -1629,7 +1406,7 @@ mod test {
                     .collect::<Vec<crate::Value>>();
                 assert_eq!(result_set, vec![Bytes(b"3".to_vec()), Bytes(b"4".to_vec())]);
             }
-            let mut result = conn.query("SELECT 1; SELECT 2; SELECT 3;").unwrap();
+            let mut result = conn.query_iter("SELECT 1; SELECT 2; SELECT 3;").unwrap();
             let mut i = 0;
             while {
                 i += 1;
@@ -1651,16 +1428,16 @@ mod test {
         fn should_work_with_named_params() {
             let mut conn = Conn::new(get_opts()).unwrap();
             {
-                let mut stmt = conn.prepare("SELECT :a, :b, :a, :c").unwrap();
-                let mut result = stmt
-                    .execute(params! {"a" => 1, "b" => 2, "c" => 3})
+                let stmt = conn.prep("SELECT :a, :b, :a, :c").unwrap();
+                let result = conn
+                    .exec_first(&stmt, params! {"a" => 1, "b" => 2, "c" => 3})
+                    .unwrap()
                     .unwrap();
-                let row = result.next().unwrap().unwrap();
-                assert_eq!((1, 2, 1, 3), from_row(row));
+                assert_eq!((1_u8, 2_u8, 1_u8, 3_u8), result);
             }
 
-            let mut result = conn
-                .prep_exec(
+            let result = conn
+                .exec_first(
                     "SELECT :a, :b, :a + :b, :c",
                     params! {
                         "a" => 1,
@@ -1668,16 +1445,17 @@ mod test {
                         "c" => 3,
                     },
                 )
+                .unwrap()
                 .unwrap();
-            let row = result.next().unwrap().unwrap();
-            assert_eq!((1, 2, 3, 3), from_row(row));
+            assert_eq!((1_u8, 2_u8, 3_u8, 3_u8), result);
         }
 
         #[test]
         fn should_return_error_on_missing_named_parameter() {
             let mut conn = Conn::new(get_opts()).unwrap();
-            let mut stmt = conn.prepare("SELECT :a, :b, :a, :c, :d").unwrap();
-            let result = stmt.execute(params! {"a" => 1, "b" => 2, "c" => 3,});
+            let stmt = conn.prep("SELECT :a, :b, :a, :c, :d").unwrap();
+            let result =
+                conn.exec_first::<_, _, crate::Row>(&stmt, params! {"a" => 1, "b" => 2, "c" => 3,});
             match result {
                 Err(DriverError(MissingNamedParameter(ref x))) if x == "d" => (),
                 _ => assert!(false),
@@ -1687,8 +1465,8 @@ mod test {
         #[test]
         fn should_return_error_on_named_params_for_positional_statement() {
             let mut conn = Conn::new(get_opts()).unwrap();
-            let mut stmt = conn.prepare("SELECT ?, ?, ?, ?, ?").unwrap();
-            let result = stmt.execute(params! {"a" => 1, "b" => 2, "c" => 3,});
+            let stmt = conn.prep("SELECT ?, ?, ?, ?, ?").unwrap();
+            let result = conn.exec_drop(&stmt, params! {"a" => 1, "b" => 2, "c" => 3,});
             match result {
                 Err(DriverError(NamedParamsForPositionalQuery)) => (),
                 _ => assert!(false),
@@ -1728,12 +1506,12 @@ mod test {
             opts.additional_capabilities(CapabilityFlags::CLIENT_FOUND_ROWS);
 
             let mut conn = Conn::new(opts).unwrap();
-            conn.query("CREATE TEMPORARY TABLE mysql.tbl (a INT, b TEXT)")
+            conn.query_drop("CREATE TEMPORARY TABLE mysql.tbl (a INT, b TEXT)")
                 .unwrap();
-            conn.query("INSERT INTO mysql.tbl (a, b) VALUES (1, 'foo')")
+            conn.query_drop("INSERT INTO mysql.tbl (a, b) VALUES (1, 'foo')")
                 .unwrap();
             let result = conn
-                .query("UPDATE mysql.tbl SET b = 'foo' WHERE a = 1")
+                .query_iter("UPDATE mysql.tbl SET b = 'foo' WHERE a = 1")
                 .unwrap();
             assert_eq!(result.affected_rows(), 1);
         }
@@ -1769,41 +1547,52 @@ mod test {
             let mut opts = OptsBuilder::from_opts(get_opts());
             opts.stmt_cache_size(0);
             let mut conn = Conn::new(opts).unwrap();
-            conn.prepare("DO 1").unwrap();
-            conn.prepare("DO 2").unwrap();
-            conn.prepare("DO 3").unwrap();
-            let row = conn
-                .first("SHOW SESSION STATUS LIKE 'Com_stmt_close';")
+
+            let stmt1 = conn.prep("DO 1").unwrap();
+            let stmt2 = conn.prep("DO 2").unwrap();
+            let stmt3 = conn.prep("DO 3").unwrap();
+
+            conn.close(stmt1).unwrap();
+            conn.close(stmt2).unwrap();
+            conn.close(stmt3).unwrap();
+
+            let status: (Value, u8) = conn
+                .query_first("SHOW SESSION STATUS LIKE 'Com_stmt_close';")
                 .unwrap()
                 .unwrap();
-            assert_eq!(from_row::<(String, usize)>(row).1, 3);
+            assert_eq!(status.1, 3);
         }
 
         #[test]
-        fn should_hold_stmt_cache_size_bound() {
+        fn should_hold_stmt_cache_size_bounds() {
             let mut opts = OptsBuilder::from_opts(get_opts());
             opts.stmt_cache_size(3);
+
             let mut conn = Conn::new(opts).unwrap();
-            conn.prepare("DO 1").unwrap();
-            conn.prepare("DO 2").unwrap();
-            conn.prepare("DO 3").unwrap();
-            conn.prepare("DO 1").unwrap();
-            conn.prepare("DO 4").unwrap();
-            conn.prepare("DO 3").unwrap();
-            conn.prepare("DO 5").unwrap();
-            conn.prepare("DO 6").unwrap();
-            let row = conn
-                .first("SHOW SESSION STATUS LIKE 'Com_stmt_close';")
+
+            conn.prep("DO 1").unwrap();
+            conn.prep("DO 2").unwrap();
+            conn.prep("DO 3").unwrap();
+            conn.prep("DO 1").unwrap();
+            conn.prep("DO 4").unwrap();
+            conn.prep("DO 3").unwrap();
+            conn.prep("DO 5").unwrap();
+            conn.prep("DO 6").unwrap();
+
+            let status: (String, usize) = conn
+                .query_first("SHOW SESSION STATUS LIKE 'Com_stmt_close'")
                 .unwrap()
                 .unwrap();
-            assert_eq!(from_row::<(String, usize)>(row).1, 3);
+
+            assert_eq!(status.1, 3);
+
             let mut order = conn
                 .stmt_cache
                 .iter()
-                .map(|(stmt, i)| (stmt.as_ref(), i))
-                .collect::<Vec<(&str, u64)>>();
+                .map(|(_, entry)| &**entry.query.0.as_ref())
+                .collect::<Vec<&str>>();
             order.sort();
-            assert_eq!(order, &[("DO 3", 5), ("DO 5", 6), ("DO 6", 7)]);
+            assert_eq!(order, &["DO 3", "DO 5", "DO 6"]);
         }
 
         #[test]
@@ -1825,20 +1614,22 @@ mod test {
 
             let mut conn = Conn::new(get_opts()).unwrap();
             if conn
-                .query("CREATE TEMPORARY TABLE mysql.tbl(a VARCHAR(32), b JSON)")
+                .query_drop("CREATE TEMPORARY TABLE mysql.tbl(a VARCHAR(32), b JSON)")
                 .is_err()
             {
-                conn.query("CREATE TEMPORARY TABLE mysql.tbl(a VARCHAR(32), b TEXT)")
+                conn.query_drop("CREATE TEMPORARY TABLE mysql.tbl(a VARCHAR(32), b TEXT)")
                     .unwrap();
             }
-            conn.prep_exec(
+            conn.exec_drop(
                 r#"INSERT INTO mysql.tbl VALUES ('hello', ?)"#,
                 (Serialized(&decodable),),
             )
             .unwrap();
 
-            let row = conn.first("SELECT a, b FROM mysql.tbl").unwrap().unwrap();
-            let (a, b): (String, Json) = from_row(row);
+            let (a, b): (String, Json) = conn
+                .query_first("SELECT a, b FROM mysql.tbl")
+                .unwrap()
+                .unwrap();
             assert_eq!(
                 (a, b),
                 (
@@ -1848,7 +1639,7 @@ mod test {
             );
 
             let row = conn
-                .first_exec("SELECT a, b FROM mysql.tbl WHERE a = ?", ("hello",))
+                .exec_first("SELECT a, b FROM mysql.tbl WHERE a = ?", ("hello",))
                 .unwrap()
                 .unwrap();
             let (a, Deserialized(b)) = from_row(row);
@@ -1880,7 +1671,7 @@ mod test {
 
                 fn assert_connect_attrs(conn: &mut Conn, expected_values: &[(&str, &str)]) {
                     let mut actual_values = HashMap::new();
-                    for row in conn.query("SELECT attr_name, attr_value FROM performance_schema.session_account_connect_attrs WHERE processlist_id = connection_id()").unwrap() {
+                    for row in conn.query_iter("SELECT attr_name, attr_value FROM performance_schema.session_account_connect_attrs WHERE processlist_id = connection_id()").unwrap() {
                         let (name, value) = from_row::<(String, String)>(row.unwrap());
                         actual_values.insert(name, value);
                     }

--- a/src/conn/opts.rs
+++ b/src/conn/opts.rs
@@ -12,6 +12,9 @@ use std::time::Duration;
 use crate::consts::CapabilityFlags;
 use crate::{LocalInfileHandler, UrlError};
 
+/// Default value for client side per-connection statement cache.
+pub const DEFAULT_STMT_CACHE_SIZE: usize = 128;
+
 /// Ssl Options.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
 pub struct SslOpts {
@@ -168,7 +171,8 @@ pub(crate) struct InnerOpts {
     /// errors.
     bind_address: Option<SocketAddr>,
 
-    /// Number of prepared statements cached on the client side (per connection). Defaults to `10`.
+    /// Number of prepared statements cached on the client side (per connection).
+    /// Defaults to [`DEFAULT_STMT_CACHE_SIZE`].
     ///
     /// Can be defined using `stmt_cache_size` connection url parameter.
     stmt_cache_size: usize,
@@ -221,7 +225,7 @@ impl Default for InnerOpts {
             local_infile_handler: None,
             tcp_connect_timeout: None,
             bind_address: None,
-            stmt_cache_size: 10,
+            stmt_cache_size: DEFAULT_STMT_CACHE_SIZE,
             compress: None,
             additional_capabilities: CapabilityFlags::empty(),
             connect_attrs: HashMap::new(),
@@ -348,7 +352,10 @@ impl Opts {
         self.0.bind_address.as_ref()
     }
 
-    /// Number of prepared statements cached on the client side (per connection). Defaults to `10`.
+    /// Number of prepared statements cached on the client side (per connection).
+    /// Defaults to [`DEFAULT_STMT_CACHE_SIZE`].
+    ///
+    /// Can be defined using `stmt_cache_size` connection url parameter.
     pub fn get_stmt_cache_size(&self) -> usize {
         self.0.stmt_cache_size
     }
@@ -594,18 +601,17 @@ impl OptsBuilder {
         self
     }
 
-    /// Number of prepared statements cached on the client side (per connection). Defaults to `10`.
-    ///
-    /// Available as `stmt_cache_size` url parameter.
-    ///
-    /// Call with `None` to reset to default.
+    /// Number of prepared statements cached on the client side (per connection).
+    /// Defaults to [`DEFAULT_STMT_CACHE_SIZE`].
     ///
     /// Can be defined using `stmt_cache_size` connection url parameter.
+    ///
+    /// Call with `None` to reset to default.
     pub fn stmt_cache_size<T>(&mut self, cache_size: T) -> &mut Self
     where
         T: Into<Option<usize>>,
     {
-        self.opts.0.stmt_cache_size = cache_size.into().unwrap_or(10);
+        self.opts.0.stmt_cache_size = cache_size.into().unwrap_or(128);
         self
     }
 

--- a/src/conn/opts.rs
+++ b/src/conn/opts.rs
@@ -34,16 +34,16 @@ impl SslOpts {
     /// ```text
     /// openssl pkcs12 -password pass: -export -out path.p12 -inkey privatekey.pem -in cert.pem -no-CAfile
     /// ```
-    pub fn set_pkcs12_path<T: Into<Cow<'static, Path>>>(
-        &mut self,
+    pub fn with_pkcs12_path<T: Into<Cow<'static, Path>>>(
+        mut self,
         pkcs12_path: Option<T>,
-    ) -> &mut Self {
+    ) -> Self {
         self.pkcs12_path = pkcs12_path.map(Into::into);
         self
     }
 
     /// Sets the password for a pkcs12 archive (defaults to `None`).
-    pub fn set_password<T: Into<Cow<'static, str>>>(&mut self, password: Option<T>) -> &mut Self {
+    pub fn with_password<T: Into<Cow<'static, str>>>(mut self, password: Option<T>) -> Self {
         self.password = password.map(Into::into);
         self
     }
@@ -56,24 +56,24 @@ impl SslOpts {
     /// ```text
     /// openssl x509 -outform der -in rootca.pem -out rootca.der
     /// ```
-    pub fn set_root_cert_path<T: Into<Cow<'static, Path>>>(
-        &mut self,
+    pub fn with_root_cert_path<T: Into<Cow<'static, Path>>>(
+        mut self,
         root_cert_path: Option<T>,
-    ) -> &mut Self {
+    ) -> Self {
         self.root_cert_path = root_cert_path.map(Into::into);
         self
     }
 
     /// The way to not validate the server's domain
     /// name against its certificate (defaults to `false`).
-    pub fn set_danger_skip_domain_validation(&mut self, value: bool) -> &mut Self {
+    pub fn with_danger_skip_domain_validation(mut self, value: bool) -> Self {
         self.skip_domain_validation = value;
         self
     }
 
     /// If `true` then client will accept invalid certificate (expired, not trusted, ..)
     /// (defaults to `false`).
-    pub fn set_danger_accept_invalid_certs(&mut self, value: bool) -> &mut Self {
+    pub fn with_danger_accept_invalid_certs(mut self, value: bool) -> Self {
         self.accept_invalid_certs = value;
         self
     }
@@ -467,14 +467,14 @@ impl OptsBuilder {
     /// Address of mysql server (defaults to `127.0.0.1`). Hostnames should also work.
     ///
     /// **Note:** IPv6 addresses must be given in square brackets, e.g. `[::1]`.
-    pub fn ip_or_hostname<T: Into<String>>(&mut self, ip_or_hostname: Option<T>) -> &mut Self {
+    pub fn ip_or_hostname<T: Into<String>>(mut self, ip_or_hostname: Option<T>) -> Self {
         let new = ip_or_hostname.map(Into::into).unwrap_or("127.0.0.1".into());
         self.opts.0.ip_or_hostname = url::Host::parse(&new).map(|host| host.to_owned()).unwrap_or_else(|_| url::Host::Domain(new.to_owned()));
         self
     }
 
     /// TCP port of mysql server (defaults to `3306`).
-    pub fn tcp_port(&mut self, tcp_port: u16) -> &mut Self {
+    pub fn tcp_port(mut self, tcp_port: u16) -> Self {
         self.opts.0.tcp_port = tcp_port;
         self
     }
@@ -482,25 +482,25 @@ impl OptsBuilder {
     /// Socket path on unix or pipe name on windows (defaults to `None`).
     ///
     /// Can be defined using `socket` connection url parameter.
-    pub fn socket<T: Into<String>>(&mut self, socket: Option<T>) -> &mut Self {
+    pub fn socket<T: Into<String>>(mut self, socket: Option<T>) -> Self {
         self.opts.0.socket = socket.map(Into::into);
         self
     }
 
     /// User (defaults to `None`).
-    pub fn user<T: Into<String>>(&mut self, user: Option<T>) -> &mut Self {
+    pub fn user<T: Into<String>>(mut self, user: Option<T>) -> Self {
         self.opts.0.user = user.map(Into::into);
         self
     }
 
     /// Password (defaults to `None`).
-    pub fn pass<T: Into<String>>(&mut self, pass: Option<T>) -> &mut Self {
+    pub fn pass<T: Into<String>>(mut self, pass: Option<T>) -> Self {
         self.opts.0.pass = pass.map(Into::into);
         self
     }
 
     /// Database name (defaults to `None`).
-    pub fn db_name<T: Into<String>>(&mut self, db_name: Option<T>) -> &mut Self {
+    pub fn db_name<T: Into<String>>(mut self, db_name: Option<T>) -> Self {
         self.opts.0.db_name = db_name.map(Into::into);
         self
     }
@@ -509,7 +509,7 @@ impl OptsBuilder {
     ///
     /// Note that named pipe connection will ignore duration's `nanos`, and also note that
     /// it is an error to pass the zero `Duration` to this method.
-    pub fn read_timeout(&mut self, read_timeout: Option<Duration>) -> &mut Self {
+    pub fn read_timeout(mut self, read_timeout: Option<Duration>) -> Self {
         self.opts.0.read_timeout = read_timeout;
         self
     }
@@ -518,7 +518,7 @@ impl OptsBuilder {
     ///
     /// Note that named pipe connection will ignore duration's `nanos`, and also note that
     /// it is likely error to pass the zero `Duration` to this method.
-    pub fn write_timeout(&mut self, write_timeout: Option<Duration>) -> &mut Self {
+    pub fn write_timeout(mut self, write_timeout: Option<Duration>) -> Self {
         self.opts.0.write_timeout = write_timeout;
         self
     }
@@ -527,7 +527,7 @@ impl OptsBuilder {
     /// `tcp_keepalive_time_ms` url parameter.
     ///
     /// Can be defined using `tcp_keepalive_time_ms` connection url parameter.
-    pub fn tcp_keepalive_time_ms(&mut self, tcp_keepalive_time_ms: Option<u32>) -> &mut Self {
+    pub fn tcp_keepalive_time_ms(mut self, tcp_keepalive_time_ms: Option<u32>) -> Self {
         self.opts.0.tcp_keepalive_time = tcp_keepalive_time_ms;
         self
     }
@@ -536,7 +536,7 @@ impl OptsBuilder {
     ///
     /// Setting this option to false re-enables Nagle's algorithm, which can cause unusually high
     /// latency (~40ms) but may increase maximum throughput. See #132.
-    pub fn tcp_nodelay(&mut self, nodelay: bool) -> &mut Self {
+    pub fn tcp_nodelay(mut self, nodelay: bool) -> Self {
         self.opts.0.tcp_nodelay = nodelay;
         self
     }
@@ -550,19 +550,19 @@ impl OptsBuilder {
     /// Will fall back to TCP on error. Use `socket` option to enforce socket connection.
     ///
     /// Can be defined using `prefer_socket` connection url parameter.
-    pub fn prefer_socket(&mut self, prefer_socket: bool) -> &mut Self {
+    pub fn prefer_socket(mut self, prefer_socket: bool) -> Self {
         self.opts.0.prefer_socket = prefer_socket;
         self
     }
 
     /// Commands to execute on each new database connection.
-    pub fn init<T: Into<String>>(&mut self, init: Vec<T>) -> &mut Self {
+    pub fn init<T: Into<String>>(mut self, init: Vec<T>) -> Self {
         self.opts.0.init = init.into_iter().map(Into::into).collect();
         self
     }
 
     /// Driver will require SSL connection if this option isn't `None` (default to `None`).
-    pub fn ssl_opts<T: Into<Option<SslOpts>>>(&mut self, ssl_opts: T) -> &mut Self {
+    pub fn ssl_opts<T: Into<Option<SslOpts>>>(mut self, ssl_opts: T) -> Self {
         self.opts.0.ssl_opts = ssl_opts.into();
         self
     }
@@ -573,7 +573,7 @@ impl OptsBuilder {
     /// to receive the contents of that file.
     /// If unset, the default callback will read files relative to
     /// the current directory.
-    pub fn local_infile_handler(&mut self, handler: Option<LocalInfileHandler>) -> &mut Self {
+    pub fn local_infile_handler(mut self, handler: Option<LocalInfileHandler>) -> Self {
         self.opts.0.local_infile_handler = handler;
         self
     }
@@ -582,7 +582,7 @@ impl OptsBuilder {
     /// url parameter.
     ///
     /// Can be defined using `tcp_connect_timeout_ms` connection url parameter.
-    pub fn tcp_connect_timeout(&mut self, timeout: Option<Duration>) -> &mut Self {
+    pub fn tcp_connect_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.opts.0.tcp_connect_timeout = timeout;
         self
     }
@@ -591,7 +591,7 @@ impl OptsBuilder {
     ///
     /// Use carefully. Will probably make pool unusable because of *address already in use*
     /// errors.
-    pub fn bind_address<T>(&mut self, bind_address: Option<T>) -> &mut Self
+    pub fn bind_address<T>(mut self, bind_address: Option<T>) -> Self
     where
         T: Into<SocketAddr>,
     {
@@ -605,7 +605,7 @@ impl OptsBuilder {
     /// Can be defined using `stmt_cache_size` connection url parameter.
     ///
     /// Call with `None` to reset to default.
-    pub fn stmt_cache_size<T>(&mut self, cache_size: T) -> &mut Self
+    pub fn stmt_cache_size<T>(mut self, cache_size: T) -> Self
     where
         T: Into<Option<usize>>,
     {
@@ -624,7 +624,7 @@ impl OptsBuilder {
     ///   "no compression";
     ///
     /// Note that compression level defined here will affect only outgoing packets.
-    pub fn compress(&mut self, compress: Option<crate::Compression>) -> &mut Self {
+    pub fn compress(mut self, compress: Option<crate::Compression>) -> Self {
         self.opts.0.compress = compress;
         self
     }
@@ -640,9 +640,9 @@ impl OptsBuilder {
     /// `CLIENT_SSL` or `CLIENT_COMPRESS`). Also note that some capabilities are reserved,
     /// pointless or may broke the connection, so this option should be used with caution.
     pub fn additional_capabilities(
-        &mut self,
+        mut self,
         additional_capabilities: CapabilityFlags,
-    ) -> &mut Self {
+    ) -> Self {
         let forbidden_flags: CapabilityFlags = CapabilityFlags::CLIENT_PROTOCOL_41
             | CapabilityFlags::CLIENT_SSL
             | CapabilityFlags::CLIENT_COMPRESS
@@ -691,9 +691,9 @@ impl OptsBuilder {
     /// [`performance_schema_session_connect_attrs_size`]: https://dev.mysql.com/doc/refman/en/performance-schema-system-variables.html#sysvar_performance_schema_session_connect_attrs_size
     ///
     pub fn connect_attrs<T1: Into<String> + Eq + Hash, T2: Into<String>>(
-        &mut self,
+        mut self,
         connect_attrs: HashMap<T1, T2>,
-    ) -> &mut Self {
+    ) -> Self {
         self.opts.0.connect_attrs = HashMap::with_capacity(connect_attrs.len());
         for (name, value) in connect_attrs {
             let name = name.into();

--- a/src/conn/opts.rs
+++ b/src/conn/opts.rs
@@ -17,7 +17,7 @@ use std::{
 use crate::{consts::CapabilityFlags, LocalInfileHandler, UrlError};
 
 /// Default value for client side per-connection statement cache.
-pub const DEFAULT_STMT_CACHE_SIZE: usize = 128;
+pub const DEFAULT_STMT_CACHE_SIZE: usize = 32;
 
 /// Ssl Options.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]

--- a/src/conn/opts.rs
+++ b/src/conn/opts.rs
@@ -1,3 +1,11 @@
+// Copyright (c) 2020 rust-mysql-common contributors
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 use percent_encoding::{percent_decode, percent_decode_str};
 use url::Url;
 

--- a/src/conn/opts.rs
+++ b/src/conn/opts.rs
@@ -1,16 +1,12 @@
 use percent_encoding::{percent_decode, percent_decode_str};
 use url::Url;
 
-use std::borrow::Cow;
-use std::collections::HashMap;
-use std::hash::Hash;
-use std::net::SocketAddr;
-use std::path::Path;
-use std::str::FromStr;
-use std::time::Duration;
+use std::{
+    borrow::Cow, collections::HashMap, hash::Hash, net::SocketAddr, path::Path, str::FromStr,
+    time::Duration,
+};
 
-use crate::consts::CapabilityFlags;
-use crate::{LocalInfileHandler, UrlError};
+use crate::{consts::CapabilityFlags, LocalInfileHandler, UrlError};
 
 /// Default value for client side per-connection statement cache.
 pub const DEFAULT_STMT_CACHE_SIZE: usize = 128;
@@ -34,10 +30,7 @@ impl SslOpts {
     /// ```text
     /// openssl pkcs12 -password pass: -export -out path.p12 -inkey privatekey.pem -in cert.pem -no-CAfile
     /// ```
-    pub fn with_pkcs12_path<T: Into<Cow<'static, Path>>>(
-        mut self,
-        pkcs12_path: Option<T>,
-    ) -> Self {
+    pub fn with_pkcs12_path<T: Into<Cow<'static, Path>>>(mut self, pkcs12_path: Option<T>) -> Self {
         self.pkcs12_path = pkcs12_path.map(Into::into);
         self
     }
@@ -469,7 +462,9 @@ impl OptsBuilder {
     /// **Note:** IPv6 addresses must be given in square brackets, e.g. `[::1]`.
     pub fn ip_or_hostname<T: Into<String>>(mut self, ip_or_hostname: Option<T>) -> Self {
         let new = ip_or_hostname.map(Into::into).unwrap_or("127.0.0.1".into());
-        self.opts.0.ip_or_hostname = url::Host::parse(&new).map(|host| host.to_owned()).unwrap_or_else(|_| url::Host::Domain(new.to_owned()));
+        self.opts.0.ip_or_hostname = url::Host::parse(&new)
+            .map(|host| host.to_owned())
+            .unwrap_or_else(|_| url::Host::Domain(new.to_owned()));
         self
     }
 
@@ -639,10 +634,7 @@ impl OptsBuilder {
     /// won't let you to interfere with capabilities managed by other options (like
     /// `CLIENT_SSL` or `CLIENT_COMPRESS`). Also note that some capabilities are reserved,
     /// pointless or may broke the connection, so this option should be used with caution.
-    pub fn additional_capabilities(
-        mut self,
-        additional_capabilities: CapabilityFlags,
-    ) -> Self {
+    pub fn additional_capabilities(mut self, additional_capabilities: CapabilityFlags) -> Self {
         let forbidden_flags: CapabilityFlags = CapabilityFlags::CLIENT_PROTOCOL_41
             | CapabilityFlags::CLIENT_SSL
             | CapabilityFlags::CLIENT_COMPRESS
@@ -769,7 +761,8 @@ fn from_url_basic(url_str: &str) -> Result<(Opts, Vec<(String, String)>), UrlErr
     }
     let user = get_opts_user_from_url(&url);
     let pass = get_opts_pass_from_url(&url);
-    let ip_or_hostname = url.host()
+    let ip_or_hostname = url
+        .host()
         .ok_or(UrlError::BadUrl)
         .and_then(|host| url::Host::parse(&host.to_string()).map_err(|_| UrlError::BadUrl))?;
     let tcp_port = url.port().unwrap_or(3306);

--- a/src/conn/pool.rs
+++ b/src/conn/pool.rs
@@ -1,5 +1,6 @@
 use std::collections::VecDeque;
 use std::fmt;
+use std::ops::Deref;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration as StdDuration;
@@ -286,6 +287,14 @@ impl fmt::Debug for Pool {
 pub struct PooledConn {
     pool: Pool,
     conn: Option<Conn>,
+}
+
+impl Deref for PooledConn {
+    type Target = Conn;
+
+    fn deref(&self) -> &Self::Target {
+        self.conn.as_ref().expect("deref after drop")
+    }
 }
 
 impl Drop for PooledConn {

--- a/src/conn/pool.rs
+++ b/src/conn/pool.rs
@@ -1,9 +1,13 @@
-use std::collections::VecDeque;
-use std::fmt;
-use std::ops::Deref;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
-use std::time::Duration as StdDuration;
+use std::{
+    collections::VecDeque,
+    fmt,
+    ops::Deref,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Condvar, Mutex,
+    },
+    time::Duration as StdDuration,
+};
 
 use crate::{
     prelude::*,
@@ -396,9 +400,9 @@ mod test {
     mod pool {
         use std::{thread, time::Duration};
 
-        use crate::prelude::*;
-        use crate::test_misc::get_opts;
-        use crate::{from_value, DriverError, Error, OptsBuilder, Pool};
+        use crate::{
+            from_value, prelude::*, test_misc::get_opts, DriverError, Error, OptsBuilder, Pool,
+        };
 
         #[test]
         fn multiple_pools_should_work() {
@@ -423,8 +427,7 @@ mod test {
                 .unwrap()
                 .exec_drop("INSERT INTO A.a VALUES (1)", ())
                 .unwrap();
-            let opts = OptsBuilder::from_opts(get_opts())
-                .db_name(Some("A"));
+            let opts = OptsBuilder::from_opts(get_opts()).db_name(Some("A"));
             let pool2 = Pool::new(opts).unwrap();
             let count: u8 = pool2
                 .get_conn()
@@ -671,8 +674,7 @@ mod test {
 
             use std::thread;
 
-            use crate::test_misc::get_opts;
-            use crate::Pool;
+            use crate::{test_misc::get_opts, Pool};
 
             #[bench]
             fn many_prepares(bencher: &mut test::Bencher) {

--- a/src/conn/pool.rs
+++ b/src/conn/pool.rs
@@ -1,3 +1,11 @@
+// Copyright (c) 2020 rust-mysql-common contributors
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 use std::{
     collections::VecDeque,
     fmt,

--- a/src/conn/pool.rs
+++ b/src/conn/pool.rs
@@ -423,9 +423,9 @@ mod test {
                 .unwrap()
                 .exec_drop("INSERT INTO A.a VALUES (1)", ())
                 .unwrap();
-            let mut builder = OptsBuilder::from_opts(get_opts());
-            builder.db_name(Some("A"));
-            let pool2 = Pool::new(builder).unwrap();
+            let opts = OptsBuilder::from_opts(get_opts())
+                .db_name(Some("A"));
+            let pool2 = Pool::new(opts).unwrap();
             let count: u8 = pool2
                 .get_conn()
                 .unwrap()

--- a/src/conn/pool.rs
+++ b/src/conn/pool.rs
@@ -1,18 +1,14 @@
-use mysql_common::named_params::parse_named_params;
-use mysql_common::row::convert::from_row;
-
-use std::borrow::Borrow;
 use std::collections::VecDeque;
 use std::fmt;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration as StdDuration;
 
-use crate::prelude::{FromRow, GenericConnection};
-use crate::time::{Duration, SteadyTime};
 use crate::{
+    prelude::*,
+    time::{Duration, SteadyTime},
     Conn, DriverError, Error, IsolationLevel, LocalInfileHandler, Opts, Params, QueryResult,
-    Result as MyResult, Row, Stmt, Transaction,
+    Result as MyResult, Statement, Transaction,
 };
 
 #[derive(Debug)]
@@ -56,37 +52,27 @@ impl InnerPool {
 /// Example of multithreaded `Pool` usage:
 ///
 /// ```rust
-/// use mysql::{Pool, Opts};
-/// # use mysql::OptsBuilder;
-/// use std::thread;
-///
-/// fn get_opts() -> Opts {
-///       // ...
-/// #     let url = if let Ok(url) = std::env::var("DATABASE_URL") {
-/// #         let opts = Opts::from_url(&url).expect("DATABASE_URL invalid");
-/// #         if opts.get_db_name().expect("a database name is required").is_empty() {
-/// #             panic!("database name is empty");
-/// #         }
-/// #         url
-/// #     } else {
-/// #         "mysql://root:password@127.0.0.1:3307/mysql".to_string()
-/// #     };
-/// #     Opts::from_url(&*url).unwrap()
-/// }
-///
+/// # mysql::doctest_wrapper!(__result, {
+/// # use mysql::*;
+/// # use mysql::prelude::*;
+/// # let mut conn = Conn::new(get_opts())?;
 /// let opts = get_opts();
 /// let pool = Pool::new(opts).unwrap();
 /// let mut threads = Vec::new();
+///
 /// for _ in 0..100 {
 ///     let pool = pool.clone();
-///     threads.push(thread::spawn(move || {
-///         let mut result = pool.prep_exec("SELECT 1", ()).unwrap();
-///         assert_eq!(result.next().unwrap().unwrap().unwrap(), vec![1.into()]);
+///     threads.push(std::thread::spawn(move || {
+///         let mut conn = pool.get_conn().unwrap();
+///         let result: u8 = conn.query_first("SELECT 1").unwrap().unwrap();
+///         assert_eq!(result, 1_u8);
 ///     }));
 /// }
+///
 /// for t in threads.into_iter() {
 ///     assert!(t.join().is_ok());
 /// }
+/// # });
 /// ```
 ///
 /// For more info on how to work with mysql connection please look at
@@ -232,57 +218,6 @@ impl Pool {
         self._get_conn(None::<String>, Some(timeout_ms), true)
     }
 
-    fn get_conn_by_stmt<T: AsRef<str>>(&self, query: T, call_ping: bool) -> MyResult<PooledConn> {
-        self._get_conn(Some(query), None, call_ping)
-    }
-
-    /// Will prepare statement. See [`Conn::prepare`](struct.Conn.html#method.prepare).
-    ///
-    /// It will try to find connection which has this statement cached.
-    pub fn prepare<T: AsRef<str>>(&self, query: T) -> MyResult<Stmt<'static>> {
-        let conn = self.get_conn_by_stmt(query.as_ref(), true)?;
-        conn.pooled_prepare(query)
-    }
-
-    /// Shortcut for `pool.get_conn()?.prep_exec(..)`. See
-    /// [`Conn::prep_exec`](struct.Conn.html#method.prep_exec).
-    ///
-    /// It will try to find connection which has this statement cached.
-    pub fn prep_exec<A, T>(&self, query: A, params: T) -> MyResult<QueryResult<'static>>
-    where
-        A: AsRef<str>,
-        T: Into<Params>,
-    {
-        let conn = self.get_conn_by_stmt(query.as_ref(), false)?;
-        let params = params.into();
-        match conn.pooled_prep_exec(query.as_ref(), params.clone()) {
-            Ok(stmt) => Ok(stmt),
-            Err(e) => {
-                if e.is_connectivity_error() {
-                    let conn = self._get_conn(None::<String>, None, true)?;
-                    conn.pooled_prep_exec(query, params)
-                } else {
-                    Err(e)
-                }
-            }
-        }
-    }
-
-    /// See [`Conn::first_exec`](struct.Conn.html#method.first_exec).
-    pub fn first_exec<Q, P>(&self, query: Q, params: P) -> MyResult<Option<Row>>
-    where
-        Q: AsRef<str>,
-        P: Into<Params>,
-    {
-        self.prep_exec(query, params).and_then(|mut result| {
-            if let Some(row) = result.next() {
-                row.map(Some)
-            } else {
-                Ok(None)
-            }
-        })
-    }
-
     /// Shortcut for `pool.get_conn()?.start_transaction(..)`.
     pub fn start_transaction(
         &self,
@@ -325,33 +260,24 @@ impl fmt::Debug for Pool {
 /// `Value::Bytes` as a result and `from_value` will need to parse it if you want, for example, `i64`
 ///
 /// ```rust
-/// # use mysql::{Pool, Opts, OptsBuilder, from_value, Value};
-/// # fn get_opts() -> Opts {
-/// #     let url = if let Ok(url) = std::env::var("DATABASE_URL") {
-/// #         let opts = Opts::from_url(&url).expect("DATABASE_URL invalid");
-/// #         if opts.get_db_name().expect("a database name is required").is_empty() {
-/// #             panic!("database name is empty");
-/// #         }
-/// #         url
-/// #     } else {
-/// #         "mysql://root:password@127.0.0.1:3307/mysql".to_string()
-/// #     };
-/// #     Opts::from_url(&*url).unwrap()
-/// # }
-/// # let opts = get_opts();
-/// # let pool = Pool::new(opts).unwrap();
+/// # mysql::doctest_wrapper!(__result, {
+/// # use mysql::*;
+/// # use mysql::prelude::*;
+/// # let mut conn = Conn::new(get_opts())?;
+/// let pool = Pool::new(get_opts()).unwrap();
 /// let mut conn = pool.get_conn().unwrap();
 ///
-/// conn.query("SELECT 42").map(|mut result| {
-///     let cell = result.next().unwrap().unwrap().take(0).unwrap();
-///     assert_eq!(cell, Value::Bytes(b"42".to_vec()));
-///     assert_eq!(from_value::<i64>(cell), 42i64);
+/// conn.query_first("SELECT 42").map(|result: Option<Value>| {
+///     let result = result.unwrap();
+///     assert_eq!(result, Value::Bytes(b"42".to_vec()));
+///     assert_eq!(from_value::<i64>(result), 42i64);
 /// }).unwrap();
-/// conn.prep_exec("SELECT 42", ()).map(|mut result| {
+/// conn.exec_iter("SELECT 42", ()).map(|mut result| {
 ///     let cell = result.next().unwrap().unwrap().take(0).unwrap();
 ///     assert_eq!(cell, Value::Int(42i64));
 ///     assert_eq!(from_value::<i64>(cell), 42i64);
 /// }).unwrap();
+/// # });
 /// ```
 ///
 /// For more info on how to work with query results please look at
@@ -379,53 +305,6 @@ impl Drop for PooledConn {
 }
 
 impl PooledConn {
-    /// Redirects to
-    /// [`Conn#query`](struct.Conn.html#method.query).
-    pub fn query<T: AsRef<str>>(&mut self, query: T) -> MyResult<QueryResult<'_>> {
-        self.conn.as_mut().unwrap().query(query)
-    }
-
-    /// See [`Conn::first`](struct.Conn.html#method.first).
-    pub fn first<T: AsRef<str>, U: FromRow>(&mut self, query: T) -> MyResult<Option<U>> {
-        self.query(query).and_then(|mut result| {
-            if let Some(row) = result.next() {
-                row.map(|x| Some(from_row(x)))
-            } else {
-                Ok(None)
-            }
-        })
-    }
-
-    /// See [`Conn::prepare`](struct.Conn.html#method.prepare).
-    pub fn prepare<T: AsRef<str>>(&mut self, query: T) -> MyResult<Stmt<'_>> {
-        self.conn.as_mut().unwrap().prepare(query)
-    }
-
-    /// See [`Conn::prep_exec`](struct.Conn.html#method.prep_exec).
-    pub fn prep_exec<A, T>(&mut self, query: A, params: T) -> MyResult<QueryResult<'_>>
-    where
-        A: AsRef<str>,
-        T: Into<Params>,
-    {
-        self.conn.as_mut().unwrap().prep_exec(query, params)
-    }
-
-    /// See [`Conn::first_exec`](struct.Conn.html#method.first_exec).
-    pub fn first_exec<Q, P, T>(&mut self, query: Q, params: P) -> MyResult<Option<T>>
-    where
-        Q: AsRef<str>,
-        P: Into<Params>,
-        T: FromRow,
-    {
-        self.prep_exec(query, params).and_then(|mut result| {
-            if let Some(row) = result.next() {
-                row.map(|x| Some(from_row(x)))
-            } else {
-                Ok(None)
-            }
-        })
-    }
-
     /// Redirects to
     /// [`Conn#start_transaction`](struct.Conn.html#method.start_transaction)
     pub fn start_transaction(
@@ -458,26 +337,6 @@ impl PooledConn {
         self.conn.take().unwrap()
     }
 
-    fn pooled_prepare<'a, T: AsRef<str>>(mut self, query: T) -> MyResult<Stmt<'a>> {
-        let query = query.as_ref();
-        let (named_params, real_query) = parse_named_params(query)?;
-        self.as_mut()
-            ._prepare(real_query.borrow(), named_params)
-            .map(|stmt| Stmt::new_pooled(stmt, self))
-    }
-
-    fn pooled_prep_exec<'a, A, T>(mut self, query: A, params: T) -> MyResult<QueryResult<'a>>
-    where
-        A: AsRef<str>,
-        T: Into<Params>,
-    {
-        let query = query.as_ref();
-        let (named_params, real_query) = parse_named_params(query)?;
-        let stmt = self.as_mut()._prepare(real_query.borrow(), named_params)?;
-        let stmt = Stmt::new_pooled(stmt, self);
-        stmt.prep_exec(params)
-    }
-
     fn pooled_start_transaction<'a>(
         mut self,
         consistent_snapshot: bool,
@@ -500,34 +359,25 @@ impl PooledConn {
     }
 }
 
-impl GenericConnection for PooledConn {
-    fn query<T: AsRef<str>>(&mut self, query: T) -> MyResult<QueryResult<'_>> {
-        self.query(query)
+impl Queryable for PooledConn {
+    fn query_iter<T: AsRef<str>>(&mut self, query: T) -> MyResult<QueryResult<'_>> {
+        self.conn.as_mut().unwrap().query_iter(query)
     }
 
-    fn first<T: AsRef<str>, U: FromRow>(&mut self, query: T) -> MyResult<Option<U>> {
-        self.first(query)
+    fn prep<T: AsRef<str>>(&mut self, query: T) -> MyResult<Statement> {
+        self.conn.as_mut().unwrap().prep(query)
     }
 
-    fn prepare<T: AsRef<str>>(&mut self, query: T) -> MyResult<Stmt<'_>> {
-        self.prepare(query)
+    fn close(&mut self, stmt: Statement) -> Result<(), Error> {
+        self.conn.as_mut().unwrap().close(stmt)
     }
 
-    fn prep_exec<A, T>(&mut self, query: A, params: T) -> MyResult<QueryResult<'_>>
+    fn exec_iter<S, P>(&mut self, stmt: S, params: P) -> MyResult<QueryResult<'_>>
     where
-        A: AsRef<str>,
-        T: Into<Params>,
-    {
-        self.prep_exec(query, params)
-    }
-
-    fn first_exec<Q, P, T>(&mut self, query: Q, params: P) -> MyResult<Option<T>>
-    where
-        Q: AsRef<str>,
+        S: AsStatement,
         P: Into<Params>,
-        T: FromRow,
     {
-        self.first_exec(query, params)
+        self.conn.as_mut().unwrap().exec_iter(stmt, params)
     }
 }
 
@@ -537,27 +387,47 @@ mod test {
     mod pool {
         use std::{thread, time::Duration};
 
+        use crate::prelude::*;
         use crate::test_misc::get_opts;
-        use crate::{from_row, from_value, params, DriverError, Error, OptsBuilder, Pool};
+        use crate::{from_value, DriverError, Error, OptsBuilder, Pool};
 
         #[test]
         fn multiple_pools_should_work() {
             let pool = Pool::new(get_opts()).unwrap();
-            pool.prep_exec("DROP DATABASE IF EXISTS A", ()).unwrap();
-            pool.prep_exec("CREATE DATABASE A", ()).unwrap();
-            pool.prep_exec("DROP TABLE IF EXISTS A.a", ()).unwrap();
-            pool.prep_exec("CREATE TABLE IF NOT EXISTS A.a (id INT)", ())
+            pool.get_conn()
+                .unwrap()
+                .exec_drop("DROP DATABASE IF EXISTS A", ())
                 .unwrap();
-            pool.prep_exec("INSERT INTO A.a VALUES (1)", ()).unwrap();
+            pool.get_conn()
+                .unwrap()
+                .exec_drop("CREATE DATABASE A", ())
+                .unwrap();
+            pool.get_conn()
+                .unwrap()
+                .exec_drop("DROP TABLE IF EXISTS A.a", ())
+                .unwrap();
+            pool.get_conn()
+                .unwrap()
+                .exec_drop("CREATE TABLE IF NOT EXISTS A.a (id INT)", ())
+                .unwrap();
+            pool.get_conn()
+                .unwrap()
+                .exec_drop("INSERT INTO A.a VALUES (1)", ())
+                .unwrap();
             let mut builder = OptsBuilder::from_opts(get_opts());
             builder.db_name(Some("A"));
             let pool2 = Pool::new(builder).unwrap();
-            let row = pool2
-                .first_exec("SELECT COUNT(*) FROM a", ())
+            let count: u8 = pool2
+                .get_conn()
+                .unwrap()
+                .exec_first("SELECT COUNT(*) FROM a", ())
                 .unwrap()
                 .unwrap();
-            assert_eq!((1u8,), from_row(row));
-            pool.prep_exec("DROP DATABASE A", ()).unwrap();
+            assert_eq!(1, count);
+            pool.get_conn()
+                .unwrap()
+                .exec_drop("DROP DATABASE A", ())
+                .unwrap();
         }
 
         struct A {
@@ -576,15 +446,19 @@ mod test {
             let pool = Pool::new_manual(2, 2, get_opts()).unwrap();
             let mut conn = pool.get_conn().unwrap();
 
-            let row = pool
-                .first_exec("SELECT CONNECTION_ID();", ())
+            let id: u32 = pool
+                .get_conn()
+                .unwrap()
+                .exec_first("SELECT CONNECTION_ID();", ())
                 .unwrap()
                 .unwrap();
-            let (id,): (u32,) = from_row(row);
 
-            conn.prep_exec("KILL CONNECTION ?", (id,)).unwrap();
+            conn.exec_drop("KILL CONNECTION ?", (id,)).unwrap();
             thread::sleep(Duration::from_millis(250));
-            pool.prepare("SHOW FULL PROCESSLIST").unwrap();
+            pool.get_conn()
+                .unwrap()
+                .prep("SHOW FULL PROCESSLIST")
+                .unwrap();
         }
 
         #[test]
@@ -592,28 +466,33 @@ mod test {
             let pool = Pool::new_manual(2, 2, get_opts()).unwrap();
             let mut conn = pool.get_conn().unwrap();
 
-            let row = pool
-                .first_exec("SELECT CONNECTION_ID();", ())
+            let id: u32 = pool
+                .get_conn()
+                .unwrap()
+                .exec_first("SELECT CONNECTION_ID();", ())
                 .unwrap()
                 .unwrap();
-            let (id,): (u32,) = from_row(row);
 
-            conn.prep_exec("KILL CONNECTION ?", (id,)).unwrap();
+            conn.exec_drop("KILL CONNECTION ?", (id,)).unwrap();
             thread::sleep(Duration::from_millis(250));
-            pool.prep_exec("SHOW FULL PROCESSLIST", ()).unwrap();
+            pool.get_conn()
+                .unwrap()
+                .exec_drop("SHOW FULL PROCESSLIST", ())
+                .unwrap();
         }
         #[test]
         fn should_fix_connectivity_errors_on_start_transaction() {
             let pool = Pool::new_manual(2, 2, get_opts()).unwrap();
             let mut conn = pool.get_conn().unwrap();
 
-            let row = pool
-                .first_exec("SELECT CONNECTION_ID();", ())
+            let id: u32 = pool
+                .get_conn()
+                .unwrap()
+                .exec_first("SELECT CONNECTION_ID();", ())
                 .unwrap()
                 .unwrap();
-            let (id,): (u32,) = from_row(row);
 
-            conn.prep_exec("KILL CONNECTION ?", (id,)).unwrap();
+            conn.exec_drop("KILL CONNECTION ?", (id,)).unwrap();
             thread::sleep(Duration::from_millis(250));
             pool.start_transaction(false, None, None).unwrap();
         }
@@ -627,7 +506,7 @@ mod test {
                     let conn = pool.get_conn();
                     assert!(conn.is_ok());
                     let mut conn = conn.unwrap();
-                    assert!(conn.query("SELECT 1").is_ok());
+                    conn.query_drop("SELECT 1").unwrap();
                 }));
             }
             for t in threads.into_iter() {
@@ -647,6 +526,7 @@ mod test {
             drop(conn1);
             assert!(pool.try_get_conn(357).is_ok());
         }
+
         #[test]
         fn should_execute_statements_on_PooledConn() {
             let pool = Pool::new(get_opts()).unwrap();
@@ -655,8 +535,8 @@ mod test {
                 let pool = pool.clone();
                 threads.push(thread::spawn(move || {
                     let mut conn = pool.get_conn().unwrap();
-                    let mut stmt = conn.prepare("SELECT 1").unwrap();
-                    assert!(stmt.execute(()).is_ok());
+                    let stmt = conn.prep("SELECT 1").unwrap();
+                    conn.exec_drop(&stmt, ()).unwrap();
                 }));
             }
             for t in threads.into_iter() {
@@ -669,104 +549,67 @@ mod test {
                 let pool = pool.clone();
                 threads.push(thread::spawn(move || {
                     let mut conn = pool.get_conn().unwrap();
-                    conn.prep_exec("SELECT ?", (1,)).unwrap();
+                    conn.exec_drop("SELECT ?", (1,)).unwrap();
                 }));
             }
             for t in threads.into_iter() {
                 assert!(t.join().is_ok());
             }
         }
-        #[test]
-        fn should_execute_statements_on_Pool() {
-            let pool = Pool::new(get_opts()).unwrap();
-            let mut threads = Vec::new();
-            for _ in 0usize..10 {
-                let pool = pool.clone();
-                threads.push(thread::spawn(move || {
-                    let mut stmt = pool.prepare("SELECT 1").unwrap();
-                    assert!(stmt.execute(()).is_ok());
-                }));
-            }
-            for t in threads.into_iter() {
-                assert!(t.join().is_ok());
-            }
 
-            let pool = Pool::new(get_opts()).unwrap();
-            let mut threads = Vec::new();
-            for _ in 0usize..10 {
-                let pool = pool.clone();
-                threads.push(thread::spawn(move || {
-                    pool.prep_exec("SELECT ?", (1,)).unwrap();
-                }));
-            }
-            for t in threads.into_iter() {
-                assert!(t.join().is_ok());
-            }
-            pool.prep_exec("SELECT 1", ())
-                .and_then(|mut res1| {
-                    pool.prep_exec("SELECT 2", ()).map(|mut res2| {
-                        let (x1,) = from_row::<(u8,)>(res1.next().unwrap().unwrap());
-                        let (x2,) = from_row::<(u8,)>(res2.next().unwrap().unwrap());
-                        assert_eq!(1, x1);
-                        assert_eq!(2, x2);
-                    })
-                })
-                .unwrap()
-        }
         #[test]
         #[allow(unused_variables)]
         fn should_start_transaction_on_Pool() {
             let pool = Pool::new_manual(1, 10, get_opts()).unwrap();
-            pool.prepare("CREATE TEMPORARY TABLE mysql.tbl(a INT)")
-                .ok()
-                .map(|mut stmt| {
-                    assert!(stmt.execute(()).is_ok());
-                });
+            pool.get_conn()
+                .unwrap()
+                .query_drop("CREATE TEMPORARY TABLE mysql.tbl(a INT)")
+                .unwrap();
             pool.start_transaction(false, None, None)
                 .and_then(|mut t| {
-                    t.query("INSERT INTO mysql.tbl(a) VALUES(1)").unwrap();
-                    t.query("INSERT INTO mysql.tbl(a) VALUES(2)").unwrap();
+                    t.query_drop("INSERT INTO mysql.tbl(a) VALUES(1)").unwrap();
+                    t.query_drop("INSERT INTO mysql.tbl(a) VALUES(2)").unwrap();
                     t.commit()
                 })
                 .unwrap();
-            pool.prepare("SELECT COUNT(a) FROM mysql.tbl")
-                .ok()
-                .map(|mut stmt| {
-                    for x in stmt.execute(()).unwrap() {
-                        let mut x = x.unwrap();
-                        assert_eq!(from_value::<u8>(x.take(0).unwrap()), 2u8);
-                    }
-                });
+            assert_eq!(
+                pool.get_conn()
+                    .unwrap()
+                    .query_first::<_, u8>("SELECT COUNT(a) FROM mysql.tbl")
+                    .unwrap()
+                    .unwrap(),
+                2_u8
+            );
             pool.start_transaction(false, None, None)
                 .and_then(|mut t| {
-                    t.query("INSERT INTO mysql.tbl(a) VALUES(1)").unwrap();
-                    t.query("INSERT INTO mysql.tbl(a) VALUES(2)").unwrap();
+                    t.query_drop("INSERT INTO mysql.tbl(a) VALUES(1)").unwrap();
+                    t.query_drop("INSERT INTO mysql.tbl(a) VALUES(2)").unwrap();
                     t.rollback()
                 })
                 .unwrap();
-            pool.prepare("SELECT COUNT(a) FROM mysql.tbl")
-                .ok()
-                .map(|mut stmt| {
-                    for x in stmt.execute(()).unwrap() {
-                        let mut x = x.unwrap();
-                        assert_eq!(from_value::<u8>(x.take(0).unwrap()), 2u8);
-                    }
-                });
+            assert_eq!(
+                pool.get_conn()
+                    .unwrap()
+                    .query_first::<_, u8>("SELECT COUNT(a) FROM mysql.tbl")
+                    .unwrap()
+                    .unwrap(),
+                2_u8
+            );
             pool.start_transaction(false, None, None)
                 .and_then(|mut t| {
-                    t.query("INSERT INTO mysql.tbl(a) VALUES(1)").unwrap();
-                    t.query("INSERT INTO mysql.tbl(a) VALUES(2)").unwrap();
+                    t.query_drop("INSERT INTO mysql.tbl(a) VALUES(1)").unwrap();
+                    t.query_drop("INSERT INTO mysql.tbl(a) VALUES(2)").unwrap();
                     Ok(())
                 })
                 .unwrap();
-            pool.prepare("SELECT COUNT(a) FROM mysql.tbl")
-                .ok()
-                .map(|mut stmt| {
-                    for x in stmt.execute(()).unwrap() {
-                        let mut x = x.unwrap();
-                        assert_eq!(from_value::<u8>(x.take(0).unwrap()), 2u8);
-                    }
-                });
+            assert_eq!(
+                pool.get_conn()
+                    .unwrap()
+                    .query_first::<_, u8>("SELECT COUNT(a) FROM mysql.tbl")
+                    .unwrap()
+                    .unwrap(),
+                2_u8
+            );
             let mut a = A { pool, x: 0 };
             let transaction = a.pool.start_transaction(false, None, None).unwrap();
             a.add();
@@ -776,70 +619,41 @@ mod test {
         fn should_start_transaction_on_PooledConn() {
             let pool = Pool::new(get_opts()).unwrap();
             let mut conn = pool.get_conn().unwrap();
-            assert!(conn
-                .query("CREATE TEMPORARY TABLE mysql.tbl(a INT)")
-                .is_ok());
-            assert!(conn
-                .start_transaction(false, None, None)
+            conn.query_drop("CREATE TEMPORARY TABLE mysql.tbl(a INT)")
+                .unwrap();
+            conn.start_transaction(false, None, None)
                 .and_then(|mut t| {
-                    assert!(t.query("INSERT INTO mysql.tbl(a) VALUES(1)").is_ok());
-                    assert!(t.query("INSERT INTO mysql.tbl(a) VALUES(2)").is_ok());
+                    t.query_drop("INSERT INTO mysql.tbl(a) VALUES(1)").unwrap();
+                    t.query_drop("INSERT INTO mysql.tbl(a) VALUES(2)").unwrap();
                     t.commit()
                 })
-                .is_ok());
-            for x in conn.query("SELECT COUNT(a) FROM mysql.tbl").unwrap() {
+                .unwrap();
+            for x in conn.query_iter("SELECT COUNT(a) FROM mysql.tbl").unwrap() {
                 let mut x = x.unwrap();
                 assert_eq!(from_value::<u8>(x.take(0).unwrap()), 2u8);
             }
-            assert!(conn
-                .start_transaction(false, None, None)
+            conn.start_transaction(false, None, None)
                 .and_then(|mut t| {
-                    assert!(t.query("INSERT INTO mysql.tbl(a) VALUES(1)").is_ok());
-                    assert!(t.query("INSERT INTO mysql.tbl(a) VALUES(2)").is_ok());
+                    t.query_drop("INSERT INTO mysql.tbl(a) VALUES(1)").unwrap();
+                    t.query_drop("INSERT INTO mysql.tbl(a) VALUES(2)").unwrap();
                     t.rollback()
                 })
-                .is_ok());
-            for x in conn.query("SELECT COUNT(a) FROM mysql.tbl").unwrap() {
+                .unwrap();
+            for x in conn.query_iter("SELECT COUNT(a) FROM mysql.tbl").unwrap() {
                 let mut x = x.unwrap();
                 assert_eq!(from_value::<u8>(x.take(0).unwrap()), 2u8);
             }
-            assert!(conn
-                .start_transaction(false, None, None)
+            conn.start_transaction(false, None, None)
                 .and_then(|mut t| {
-                    assert!(t.query("INSERT INTO mysql.tbl(a) VALUES(1)").is_ok());
-                    assert!(t.query("INSERT INTO mysql.tbl(a) VALUES(2)").is_ok());
+                    t.query_drop("INSERT INTO mysql.tbl(a) VALUES(1)").unwrap();
+                    t.query_drop("INSERT INTO mysql.tbl(a) VALUES(2)").unwrap();
                     Ok(())
                 })
-                .is_ok());
-            for x in conn.query("SELECT COUNT(a) FROM mysql.tbl").unwrap() {
+                .unwrap();
+            for x in conn.query_iter("SELECT COUNT(a) FROM mysql.tbl").unwrap() {
                 let mut x = x.unwrap();
                 assert_eq!(from_value::<u8>(x.take(0).unwrap()), 2u8);
             }
-        }
-        #[test]
-        fn should_work_with_named_params() {
-            let pool = Pool::new(get_opts()).unwrap();
-            pool.prepare("SELECT :a, :b, :a + :b, :abc")
-                .map(|mut stmt| {
-                    let mut result = stmt
-                        .execute(params! {
-                            "a" => 1,
-                            "b" => 2,
-                            "abc" => 4,
-                        })
-                        .unwrap();
-                    let row = result.next().unwrap().unwrap();
-                    assert_eq!((1, 2, 3, 4), from_row(row));
-                })
-                .unwrap();
-
-            let params = params! {"a" => 1, "b" => 2, "abc" => 4};
-            pool.prep_exec("SELECT :a, :b, :a+:b, :abc", params)
-                .map(|mut result| {
-                    let row = result.next().unwrap().unwrap();
-                    assert_eq!((1, 2, 3, 4), from_row(row));
-                })
-                .unwrap();
         }
 
         #[cfg(feature = "nightly")]

--- a/src/conn/pool.rs
+++ b/src/conn/pool.rs
@@ -584,7 +584,7 @@ mod test {
             assert_eq!(
                 pool.get_conn()
                     .unwrap()
-                    .query_first::<_, u8>("SELECT COUNT(a) FROM mysql.tbl")
+                    .query_first::<u8, _>("SELECT COUNT(a) FROM mysql.tbl")
                     .unwrap()
                     .unwrap(),
                 2_u8
@@ -599,7 +599,7 @@ mod test {
             assert_eq!(
                 pool.get_conn()
                     .unwrap()
-                    .query_first::<_, u8>("SELECT COUNT(a) FROM mysql.tbl")
+                    .query_first::<u8, _>("SELECT COUNT(a) FROM mysql.tbl")
                     .unwrap()
                     .unwrap(),
                 2_u8
@@ -614,7 +614,7 @@ mod test {
             assert_eq!(
                 pool.get_conn()
                     .unwrap()
-                    .query_first::<_, u8>("SELECT COUNT(a) FROM mysql.tbl")
+                    .query_first::<u8, _>("SELECT COUNT(a) FROM mysql.tbl")
                     .unwrap()
                     .unwrap(),
                 2_u8

--- a/src/conn/query_result.rs
+++ b/src/conn/query_result.rs
@@ -1,3 +1,11 @@
+// Copyright (c) 2020 rust-mysql-common contributors
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 use mysql_common::row::new_row;
 
 use std::{collections::hash_map::HashMap, sync::Arc};

--- a/src/conn/query_result.rs
+++ b/src/conn/query_result.rs
@@ -1,39 +1,8 @@
-use fnv::FnvHasher;
 use mysql_common::row::new_row;
 
-use std::collections::hash_map::HashMap;
-use std::hash::BuildHasherDefault as BldHshrDflt;
-use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
+use std::{collections::hash_map::HashMap, sync::Arc};
 
-use crate::{Column, Conn, Result as MyResult, Row, Stmt};
-
-/// Possible ways to pass conn to a query result
-#[derive(Debug)]
-pub enum ResultConnRef<'a> {
-    ViaConnRef(&'a mut Conn),
-    ViaStmt(Stmt<'a>),
-}
-
-impl<'a> Deref for ResultConnRef<'a> {
-    type Target = Conn;
-
-    fn deref(&self) -> &Conn {
-        match *self {
-            ResultConnRef::ViaConnRef(ref conn_ref) => conn_ref,
-            ResultConnRef::ViaStmt(ref stmt) => stmt.conn.deref(),
-        }
-    }
-}
-
-impl<'a> DerefMut for ResultConnRef<'a> {
-    fn deref_mut(&mut self) -> &mut Conn {
-        match *self {
-            ResultConnRef::ViaConnRef(ref mut conn_ref) => conn_ref,
-            ResultConnRef::ViaStmt(ref mut stmt) => stmt.conn.deref_mut(),
-        }
-    }
-}
+use crate::{Column, Conn, Result as MyResult, Row};
 
 /// Mysql result set for text and binary protocols.
 ///
@@ -44,46 +13,17 @@ impl<'a> DerefMut for ResultConnRef<'a> {
 /// [`Row`](struct.Row.html) you should rely on `FromRow` trait implemented for tuples of
 /// `FromValue` implementors up to arity 12, or on `FromValue` trait for rows with higher arity.
 ///
-/// ```rust
-/// # use mysql::Pool;
-/// # use mysql::{Opts, OptsBuilder, from_row};
-/// # fn get_opts() -> Opts {
-/// #     let url = if let Ok(url) = std::env::var("DATABASE_URL") {
-/// #         let opts = Opts::from_url(&url).expect("DATABASE_URL invalid");
-/// #         if opts.get_db_name().expect("a database name is required").is_empty() {
-/// #             panic!("database name is empty");
-/// #         }
-/// #         url
-/// #     } else {
-/// #         "mysql://root:password@127.0.0.1:3307/mysql".to_string()
-/// #     };
-/// #     Opts::from_url(&*url).unwrap()
-/// # }
-/// # let opts = get_opts();
-/// # let pool = Pool::new(opts).unwrap();
-/// let mut conn = pool.get_conn().unwrap();
-///
-/// for row in conn.prep_exec("SELECT ?, ?", (42, 2.5)).unwrap() {
-///     let (a, b) = from_row(row.unwrap());
-///     assert_eq!((a, b), (42u8, 2.5_f32));
-/// }
-/// ```
-///
 /// For more info on how to work with values please look at
 /// [`Value`](../value/enum.Value.html) documentation.
 #[derive(Debug)]
 pub struct QueryResult<'a> {
-    conn: ResultConnRef<'a>,
+    conn: &'a mut Conn,
     columns: Arc<Vec<Column>>,
     is_bin: bool,
 }
 
 impl<'a> QueryResult<'a> {
-    pub(crate) fn new(
-        conn: ResultConnRef<'a>,
-        columns: Vec<Column>,
-        is_bin: bool,
-    ) -> QueryResult<'a> {
+    pub(crate) fn new(conn: &'a mut Conn, columns: Vec<Column>, is_bin: bool) -> QueryResult<'a> {
         QueryResult {
             conn,
             columns: Arc::new(columns),
@@ -105,23 +45,17 @@ impl<'a> QueryResult<'a> {
         }
     }
 
-    /// Returns
-    /// [`OkPacket`'s](http://dev.mysql.com/doc/internals/en/packet-OK_Packet.html)
-    /// affected rows.
+    /// Returns number affected rows for the current result set.
     pub fn affected_rows(&self) -> u64 {
         self.conn.affected_rows
     }
 
-    /// Returns
-    /// [`OkPacket`'s](http://dev.mysql.com/doc/internals/en/packet-OK_Packet.html)
-    /// last insert id.
+    /// Returns the last insert id for the current result set.
     pub fn last_insert_id(&self) -> u64 {
         self.conn.last_insert_id
     }
 
-    /// Returns
-    /// [`OkPacket`'s](http://dev.mysql.com/doc/internals/en/packet-OK_Packet.html)
-    /// warnings count.
+    /// Returns warnings count for the current result set.
     pub fn warnings(&self) -> u16 {
         self.conn.warnings
     }
@@ -148,8 +82,8 @@ impl<'a> QueryResult<'a> {
         None
     }
 
-    /// Returns HashMap which maps column names to column indexes.
-    pub fn column_indexes(&self) -> HashMap<String, usize, BldHshrDflt<FnvHasher>> {
+    /// Returns a `HashMap` which maps column names to column indexes.
+    pub fn column_indexes(&self) -> HashMap<String, usize> {
         let mut indexes = HashMap::default();
         for (i, column) in self.columns.iter().enumerate() {
             indexes.insert(column.name_str().into_owned(), i);
@@ -157,34 +91,40 @@ impl<'a> QueryResult<'a> {
         indexes
     }
 
-    /// Returns a slice of a [`Column`s](struct.Column.html) which represents
-    /// `QueryResult`'s columns if any.
+    /// Returns a list of columns in the current result set.
     pub fn columns_ref(&self) -> &[Column] {
         self.columns.as_ref()
     }
 
-    /// This predicate will help you to consume multiple result sets.
+    /// Returns `true` if this query result contains another result set,
+    /// or if last result set isn't fully consumed.
     ///
     /// # Note
     ///
-    /// Note that it'll also return `true` for unconsumed singe-result set.
+    /// Note, that the metadata of a query result (number of affected rows, last insert id etc.)
+    /// will change on the result set boundary, i.e:
     ///
-    /// # Example
+    /// ```rust
+    /// # mysql::doctest_wrapper!(__result, {
+    /// # use mysql::*;
+    /// # use mysql::prelude::*;
+    /// # let mut conn = Conn::new(get_opts())?;
+    /// let mut result = conn.query_iter("SELECT 1; SELECT 'foo', 'bar';")?;
     ///
-    /// ```ignore
-    /// conn.query(r#"
-    ///            CREATE PROCEDURE multi() BEGIN
-    ///                SELECT 1;
-    ///                SELECT 2;
-    ///            END
-    ///            "#);
-    /// let mut result = conn.query("CALL multi()").unwrap();
-    /// while result.more_results_exists() {
-    ///     for x in result.by_ref() {
-    ///         // On first iteration of `while` you will get result set from
-    ///         // SELECT 1 and from SELECT 2 on second.
-    ///     }
-    /// }
+    /// // First result set contains one column.
+    /// assert_eq!(result.columns_ref().len(), 1);
+    /// for row in result.by_ref() {} // first result set was consumed
+    ///
+    /// // More results exists
+    /// assert!(result.more_results_exists());
+    ///
+    /// // Second result set contains two columns.
+    /// assert_eq!(result.columns_ref().len(), 2);
+    /// for row in result.by_ref() {} // second result set was consumed
+    ///
+    /// // No more results
+    /// assert!(result.more_results_exists() == false);
+    /// # });
     /// ```
     pub fn more_results_exists(&self) -> bool {
         self.conn.more_results_exists() || !self.consumed()

--- a/src/conn/stmt.rs
+++ b/src/conn/stmt.rs
@@ -1,48 +1,35 @@
-use mysql_common::packets::ComStmtClose;
+use mysql_common::packets::{parse_stmt_packet, StmtPacket};
 
-use std::io;
+use std::{borrow::Cow, io, sync::Arc};
 
-use crate::conn::query_result::ResultConnRef;
-use crate::conn::ConnRef;
-use crate::{from_row, prelude::FromRow, Column, Conn, Params, PooledConn, QueryResult, Result};
+use crate::{prelude::*, Column, Result};
 
-#[derive(Eq, PartialEq, Clone, Debug)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct InnerStmt {
-    /// Positions and names of named parameters
-    named_params: Option<Vec<String>>,
-    params: Option<Vec<Column>>,
     columns: Option<Vec<Column>>,
-    statement_id: u32,
-    num_columns: u16,
-    num_params: u16,
-    warning_count: u16,
+    params: Option<Vec<Column>>,
+    stmt_packet: StmtPacket,
 }
 
 impl InnerStmt {
-    pub fn from_payload(pld: &[u8], named_params: Option<Vec<String>>) -> io::Result<InnerStmt> {
-        let stmt_packet = mysql_common::packets::parse_stmt_packet(pld)?;
+    pub fn from_payload(pld: &[u8]) -> io::Result<InnerStmt> {
+        let stmt_packet = parse_stmt_packet(pld)?;
 
         Ok(InnerStmt {
-            named_params,
-            statement_id: stmt_packet.statement_id(),
-            num_columns: stmt_packet.num_columns(),
-            num_params: stmt_packet.num_params(),
-            warning_count: stmt_packet.warning_count(),
-            params: None,
             columns: None,
+            params: None,
+            stmt_packet,
         })
     }
 
-    pub fn set_named_params(&mut self, named_params: Option<Vec<String>>) {
-        self.named_params = named_params;
-    }
-
-    pub fn set_params(&mut self, params: Option<Vec<Column>>) {
+    pub fn with_params(mut self, params: Option<Vec<Column>>) -> Self {
         self.params = params;
+        self
     }
 
-    pub fn set_columns(&mut self, columns: Option<Vec<Column>>) {
-        self.columns = columns
+    pub fn with_columns(mut self, columns: Option<Vec<Column>>) -> Self {
+        self.columns = columns;
+        self
     }
 
     pub fn columns(&self) -> Option<&[Column]> {
@@ -54,173 +41,68 @@ impl InnerStmt {
     }
 
     pub fn id(&self) -> u32 {
-        self.statement_id
+        self.stmt_packet.statement_id()
     }
 
     pub fn num_params(&self) -> u16 {
-        self.num_params
+        self.stmt_packet.num_params()
     }
 
     pub fn num_columns(&self) -> u16 {
-        self.num_columns
-    }
-
-    pub fn named_params(&self) -> Option<&Vec<String>> {
-        self.named_params.as_ref()
+        self.stmt_packet.num_columns()
     }
 }
 
-/// Mysql [prepared statement][1].
-///
-/// [1]: http://dev.mysql.com/doc/internals/en/prepared-statements.html
-#[derive(Debug)]
-pub struct Stmt<'a> {
-    stmt: InnerStmt,
-    pub(crate) conn: ConnRef<'a>,
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Statement {
+    pub(crate) inner: Arc<InnerStmt>,
+    pub(crate) named_params: Option<Vec<String>>,
 }
 
-impl<'a> Stmt<'a> {
-    pub(crate) fn new(stmt: InnerStmt, conn: &'a mut Conn) -> Stmt<'a> {
-        Stmt {
-            stmt,
-            conn: ConnRef::ViaConnRef(conn),
+impl Statement {
+    pub(crate) fn new(inner: Arc<InnerStmt>, named_params: Option<Vec<String>>) -> Self {
+        Self {
+            inner,
+            named_params,
         }
     }
 
-    pub(crate) fn new_pooled(stmt: InnerStmt, pooled_conn: PooledConn) -> Stmt<'a> {
-        Stmt {
-            stmt,
-            conn: ConnRef::ViaPooledConn(pooled_conn),
-        }
+    pub fn columns(&self) -> Option<&[Column]> {
+        self.inner.columns()
     }
 
-    /// Returns a slice of a [`Column`s](struct.Column.html) which represents
-    /// `Stmt`'s params if any.
-    pub fn params_ref(&self) -> Option<&[Column]> {
-        self.stmt.params()
+    pub fn params(&self) -> Option<&[Column]> {
+        self.inner.params()
     }
 
-    /// Returns a slice of a [`Column`s](struct.Column.html) which represents
-    /// `Stmt`'s columns if any.
-    pub fn columns_ref(&self) -> Option<&[Column]> {
-        self.stmt.columns()
+    pub fn id(&self) -> u32 {
+        self.inner.id()
     }
 
-    /// Returns index of a `Stmt`'s column by name.
-    pub fn column_index<T: AsRef<str>>(&self, name: T) -> Option<usize> {
-        match self.stmt.columns() {
-            None => None,
-            Some(columns) => {
-                let name = name.as_ref().as_bytes();
-                for (i, c) in columns.iter().enumerate() {
-                    if c.name_ref() == name {
-                        return Some(i);
-                    }
-                }
-                None
-            }
-        }
+    pub fn num_params(&self) -> u16 {
+        self.inner.num_params()
     }
 
-    /// Executes prepared statement with parameters passed as a [`Into<Params>`] implementor.
-    ///
-    /// ```rust
-    /// # use mysql::{Pool, Opts, OptsBuilder, from_value, from_row, Value};
-    /// # use mysql::prelude::ToValue;
-    /// # use std::default::Default;
-    /// # use std::iter::repeat;
-    /// # fn get_opts() -> Opts {
-    /// #     let url = if let Ok(url) = std::env::var("DATABASE_URL") {
-    /// #         let opts = Opts::from_url(&url).expect("DATABASE_URL invalid");
-    /// #         if opts.get_db_name().expect("a database name is required").is_empty() {
-    /// #             panic!("database name is empty");
-    /// #         }
-    /// #         url
-    /// #     } else {
-    /// #         "mysql://root:password@127.0.0.1:3307/mysql".to_string()
-    /// #     };
-    /// #     Opts::from_url(&*url).unwrap()
-    /// # }
-    /// # let opts = get_opts();
-    /// # let pool = Pool::new(opts).unwrap();
-    /// let mut stmt0 = pool.prepare("SELECT 42").unwrap();
-    /// let mut stmt1 = pool.prepare("SELECT ?").unwrap();
-    /// let mut stmt2 = pool.prepare("SELECT ?, ?").unwrap();
-    /// let mut stmt13 = pool.prepare("SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?").unwrap();
-    ///
-    /// // It is better to pass params as a tuple when executing statements of arity <= 12
-    /// for row in stmt0.execute(()).unwrap() {
-    ///     let cell = from_row::<u8>(row.unwrap());
-    ///     assert_eq!(cell, 42u8);
-    /// }
-    /// // just do not forget about trailing comma in case of arity = 1
-    /// for row in stmt1.execute((42,)).unwrap() {
-    ///     let cell = from_row::<u8>(row.unwrap());
-    ///     assert_eq!(cell, 42u8);
-    /// }
-    ///
-    /// // If you don't want to lose ownership of param, then you should pass it by reference
-    /// let word = "hello".to_string();
-    /// for row in stmt2.execute((&word, &word)).unwrap() {
-    ///     let (cell1, cell2) = from_row::<(String, String)>(row.unwrap());
-    ///     assert_eq!(cell1, "hello");
-    ///     assert_eq!(cell2, "hello");
-    /// }
-    ///
-    /// // If you want to execute statement of arity > 12, then you can pass params as &[&ToValue].
-    /// let params: &[&dyn ToValue] = &[&1, &2, &3, &4, &5, &6, &7, &8, &9, &10, &11, &12, &13];
-    /// for row in stmt13.execute(params).unwrap() {
-    ///     let row: Vec<u8> = row.unwrap().unwrap().into_iter().map(from_value::<u8>).collect();
-    ///     assert_eq!(row, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
-    /// }
-    /// // but be aware of implicit copying, so if you have huge params and do not care
-    /// // about ownership, then better to use plain Vec<Value>.
-    /// let mut params: Vec<Value> = Vec::with_capacity(13);
-    /// for i in 1..14 {
-    ///     params.push(repeat('A').take(i * 1000).collect::<String>().into());
-    /// }
-    /// for row in stmt13.execute(params).unwrap() {
-    ///     let row = row.unwrap();
-    ///     let row: Vec<String> = row.unwrap().into_iter().map(from_value::<String>).collect();
-    ///     for i in 1..14 {
-    ///         assert_eq!(row[i-1], repeat('A').take(i * 1000).collect::<String>());
-    ///     }
-    /// }
-    /// ```
-    pub fn execute<T: Into<Params>>(&mut self, params: T) -> Result<QueryResult> {
-        self.conn.execute(&self.stmt, params)
-    }
-
-    /// See [`Conn::first_exec`](struct.Conn.html#method.first_exec).
-    pub fn first_exec<P, T>(&mut self, params: P) -> Result<Option<T>>
-    where
-        P: Into<Params>,
-        T: FromRow,
-    {
-        self.execute(params).and_then(|mut result| {
-            if let Some(row) = result.next() {
-                row.map(|x| Some(from_row(x)))
-            } else {
-                Ok(None)
-            }
-        })
-    }
-
-    pub(crate) fn prep_exec<T: Into<Params>>(mut self, params: T) -> Result<QueryResult<'a>> {
-        let columns = self.conn._execute(&self.stmt, params.into())?;
-        Ok(QueryResult::new(
-            ResultConnRef::ViaStmt(self),
-            columns,
-            true,
-        ))
+    pub fn num_columns(&self) -> u16 {
+        self.inner.num_columns()
     }
 }
 
-impl<'a> Drop for Stmt<'a> {
-    fn drop(&mut self) {
-        if self.conn.stmt_cache.get_cap() == 0 {
-            let com_stmt_close = ComStmtClose::new(self.stmt.id());
-            let _ = self.conn.write_command_raw(com_stmt_close);
-        }
+impl AsStatement for Statement {
+    fn as_statement<Q: Queryable>(&self, _queryable: &mut Q) -> Result<Cow<'_, Statement>> {
+        Ok(Cow::Borrowed(self))
+    }
+}
+
+impl<'a> AsStatement for &'a Statement {
+    fn as_statement<Q: Queryable>(&self, _queryable: &mut Q) -> Result<Cow<'_, Statement>> {
+        Ok(Cow::Borrowed(self))
+    }
+}
+
+impl<T: AsRef<str>> AsStatement for T {
+    fn as_statement<Q: Queryable>(&self, queryable: &mut Q) -> Result<Cow<'static, Statement>> {
+        let statement = queryable.prep(self.as_ref())?;
+        Ok(Cow::Owned(statement))
     }
 }

--- a/src/conn/stmt.rs
+++ b/src/conn/stmt.rs
@@ -34,12 +34,12 @@ impl InnerStmt {
         self
     }
 
-    pub fn columns(&self) -> Option<&[Column]> {
-        self.columns.as_ref().map(AsRef::as_ref)
+    pub fn columns(&self) -> &[Column] {
+        self.columns.as_ref().map(AsRef::as_ref).unwrap_or(&[])
     }
 
-    pub fn params(&self) -> Option<&[Column]> {
-        self.params.as_ref().map(AsRef::as_ref)
+    pub fn params(&self) -> &[Column] {
+        self.params.as_ref().map(AsRef::as_ref).unwrap_or(&[])
     }
 
     pub fn id(&self) -> u32 {
@@ -73,11 +73,11 @@ impl Statement {
         }
     }
 
-    pub fn columns(&self) -> Option<&[Column]> {
+    pub fn columns(&self) -> &[Column] {
         self.inner.columns()
     }
 
-    pub fn params(&self) -> Option<&[Column]> {
+    pub fn params(&self) -> &[Column] {
         self.inner.params()
     }
 

--- a/src/conn/stmt.rs
+++ b/src/conn/stmt.rs
@@ -9,16 +9,18 @@ pub struct InnerStmt {
     columns: Option<Vec<Column>>,
     params: Option<Vec<Column>>,
     stmt_packet: StmtPacket,
+    connection_id: u32,
 }
 
 impl InnerStmt {
-    pub fn from_payload(pld: &[u8]) -> io::Result<InnerStmt> {
+    pub fn from_payload(pld: &[u8], connection_id: u32) -> io::Result<InnerStmt> {
         let stmt_packet = parse_stmt_packet(pld)?;
 
         Ok(InnerStmt {
             columns: None,
             params: None,
             stmt_packet,
+            connection_id,
         })
     }
 
@@ -42,6 +44,10 @@ impl InnerStmt {
 
     pub fn id(&self) -> u32 {
         self.stmt_packet.statement_id()
+    }
+
+    pub const fn connection_id(&self) -> u32 {
+        self.connection_id
     }
 
     pub fn num_params(&self) -> u16 {
@@ -77,6 +83,10 @@ impl Statement {
 
     pub fn id(&self) -> u32 {
         self.inner.id()
+    }
+
+    pub fn connection_id(&self) -> u32 {
+        self.inner.connection_id()
     }
 
     pub fn num_params(&self) -> u16 {

--- a/src/conn/stmt.rs
+++ b/src/conn/stmt.rs
@@ -1,3 +1,11 @@
+// Copyright (c) 2020 rust-mysql-common contributors
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 use mysql_common::packets::{parse_stmt_packet, StmtPacket};
 
 use std::{borrow::Cow, io, sync::Arc};

--- a/src/conn/stmt_cache.rs
+++ b/src/conn/stmt_cache.rs
@@ -1,3 +1,11 @@
+// Copyright (c) 2020 rust-mysql-common contributors
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 use lru::LruCache;
 use twox_hash::XxHash;
 

--- a/src/conn/stmt_cache.rs
+++ b/src/conn/stmt_cache.rs
@@ -94,6 +94,12 @@ impl StmtCache {
         self.cache.clear();
     }
 
+    pub fn remove(&mut self, id: u32) {
+        if let Some(entry) = self.cache.pop(&id) {
+            self.query_map.remove::<str>(entry.query.borrow());
+        }
+    }
+
     #[cfg(test)]
     pub fn iter(&self) -> impl Iterator<Item = (&u32, &Entry)> {
         self.cache.iter()

--- a/src/conn/transaction.rs
+++ b/src/conn/transaction.rs
@@ -1,3 +1,11 @@
+// Copyright (c) 2020 rust-mysql-common contributors
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 use std::fmt;
 
 use crate::{

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,11 @@
+// Copyright (c) 2020 rust-mysql-common contributors
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 use mysql_common::{
     named_params::MixedParamsError, packets::ErrPacket, params::MissingNamedParameterError,
     proto::codec::error::PacketCodecError, row::convert::FromRowError,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,8 @@
-use mysql_common::named_params::MixedParamsError;
-use mysql_common::packets::ErrPacket;
-use mysql_common::params::MissingNamedParameterError;
-use mysql_common::proto::codec::error::PacketCodecError;
-use mysql_common::row::convert::FromRowError;
-use mysql_common::value::convert::FromValueError;
+use mysql_common::{
+    named_params::MixedParamsError, packets::ErrPacket, params::MissingNamedParameterError,
+    proto::codec::error::PacketCodecError, row::convert::FromRowError,
+    value::convert::FromValueError,
+};
 use url::ParseError;
 
 use std::{error, fmt, io, result, sync};

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -4,18 +4,24 @@ use io_enum::*;
 use named_pipe as np;
 use native_tls::{Certificate, Identity, TlsConnector, TlsStream};
 
-use std::fmt;
-use std::fs::File;
-use std::io::{self, Read as _};
-use std::net::{self, SocketAddr};
 #[cfg(unix)]
 use std::os::unix;
-use std::time::Duration;
+use std::{
+    fmt,
+    fs::File,
+    io::{self, Read as _},
+    net::{self, SocketAddr},
+    time::Duration,
+};
 
-use crate::error::DriverError::{ConnectTimeout, CouldNotConnect};
-use crate::error::Error::DriverError;
-use crate::error::Result as MyResult;
-use crate::SslOpts;
+use crate::{
+    error::{
+        DriverError::{ConnectTimeout, CouldNotConnect},
+        Error::DriverError,
+        Result as MyResult,
+    },
+    SslOpts,
+};
 
 mod tcp;
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,3 +1,11 @@
+// Copyright (c) 2020 rust-mysql-common contributors
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 use bufstream::BufStream;
 use io_enum::*;
 #[cfg(windows)]

--- a/src/io/tcp.rs
+++ b/src/io/tcp.rs
@@ -1,3 +1,11 @@
+// Copyright (c) 2020 rust-mysql-common contributors
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 use net2::{TcpBuilder, TcpStreamExt};
 #[cfg(unix)]
 use nix::{

--- a/src/io/tcp.rs
+++ b/src/io/tcp.rs
@@ -8,11 +8,13 @@ use nix::{
 #[cfg(target_os = "windows")]
 use winapi::um::winsock2::*;
 
-use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 #[cfg(unix)]
 use std::os::unix::prelude::*;
-use std::time::Duration;
-use std::{io, mem};
+use std::{
+    io, mem,
+    net::{SocketAddr, TcpStream, ToSocketAddrs},
+    time::Duration,
+};
 #[cfg(target_os = "windows")]
 use std::{os::raw::*, os::windows::prelude::*, ptr};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -511,11 +511,13 @@
 //! # });
 //! ```
 //!
-//! ## Binary protocol
+//! ## Binary protocol and prepared statements.
 //!
-//! MySql binary protocol is implemented in the set of `Conn::exec*` methods. It's useful when your
-//! query have parameters. MySql uses `?` symbol as a parameter placeholder and it's only possible
-//! to use parameters where a single MySql value is expected. For example:
+//! MySql binary protocol is implemented in `prep, `close` and the set of `exec*` methods,
+//! defined on the [`Queryable`](#queryable) trait. Prepared statements is the only way to
+//! pass rust value to the MySql server. MySql uses `?` symbol as a parameter placeholder
+//! and it's only possible to use parameters where a single MySql value is expected.
+//! For example:
 //!
 //! ```rust
 //! # mysql::doctest_wrapper!(__result, {
@@ -609,6 +611,27 @@
 //! assert_eq!((13, foo, 13), val_13);
 //! # });
 //! ```
+//!
+//! ### `Queryable`
+//!
+//! The `Queryable` trait defines common methods for `Conn`, `PooledConn` and `Transaction`.
+//! The set of basic methods consts of:
+//!
+//! *   `query_iter` - basic methods to execute text query and get `QueryRestul`;
+//! *   `prep` - basic method to prepare a statement;
+//! *   `exec_iter` - basic method to execute statement and get `QueryResult`;
+//! *   `close` - basic method to close the statement;
+//!
+//! The trait also defines the set of helper methods, that is based on basic methods.
+//! These methods will consume only the firt result set, other result sets will be dropped:
+//!
+//! *   `{query|exec}` - to collect the result into a `Vec<T: FromRow>`;
+//! *   `{query|exec}_first` - to get the first `T: FromRow`, if any;
+//! *   `{query|exec}_map` - to map each `T: FromRow` to some `U`;
+//! *   `{query|exec}_fold` - to fold the set of `T: FromRow` to a single value;
+//! *   `{query|exec}_drop` - to immediately drop the result.
+//!
+//! The trait also defines additional helper for a batch statement execution.
 //!
 //! [crate docs]: https://docs.rs/mysql
 //! [mysql_common docs]: https://docs.rs/mysql_common

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,11 @@
+// Copyright (c) 2020 rust-mysql-common contributors
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 //! This create offers:
 //!
 //! *   MySql database driver in pure rust;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,44 @@
-//! ### rust-mysql-simple
-//! Mysql client library implemented in rust.
+//! # rust-mysql-simple
 //!
-//! #### Install
-//! Please use *mysql* crate:
+//! **Crate name:** mysql
+//!
+//! This create offers:
+//!
+//! *   MySql database driver in pure rust;
+//! *   connection pool.
+//!
+//! Features:
+//!
+//! *   macOS, Windows and Linux support;
+//! *   TLS support via **nativetls** create;
+//! *   MySql text protocol support, i.e. support of simple text queries and text result sets;
+//! *   MySql binary protocol support, i.e. support of prepared statements and binary result sets;
+//! *   support of multi-result sets;
+//! *   support of named parameters for prepared statements;
+//! *   optional per-connection cache of prepared statements;
+//! *   support of MySql packets larger than 2^24;
+//! *   support of Unix sockets and Windows named pipes;
+//! *   support of custom LOCAL INFILE handlers;
+//! *   support of MySql protocol compression;
+//! *   support of auth plugins:
+//!     *   **mysql_native_password** - for MySql prior to v8;
+//!     *   **caching_sha2_password** - for MySql v8 and higher.
+//!
+//! ## Installation
+//!
+//! Put the desired version of the crate into the `dependencies` section of your `Cargo.toml`:
 //!
 //! ```toml
 //! [dependencies]
 //! mysql = "*"
 //! ```
 //!
-//! #### Example
+//! ## Example
 //!
 //! ```rust
-//! #[macro_use]
-//! extern crate mysql;
-//! // ...
-//!
-//! # fn main() {
-//! use mysql as my;
-//! use my::prelude::*;
+//! # mysql::doctest_wrapper!(__result, {
+//! use mysql::*;
+//! use mysql::prelude::*;
 //!
 //! #[derive(Debug, PartialEq, Eq)]
 //! struct Payment {
@@ -27,78 +47,332 @@
 //!     account_name: Option<String>,
 //! }
 //!
-//! # fn get_opts() -> my::Opts {
-//! #     let url = if let Ok(url) = std::env::var("DATABASE_URL") {
-//! #         let opts = my::Opts::from_url(&url).expect("DATABASE_URL invalid");
-//! #         if opts.get_db_name().expect("a database name is required").is_empty() {
-//! #             panic!("database name is empty");
-//! #         }
-//! #         url
-//! #     } else {
-//! #         "mysql://root:password@127.0.0.1:3307/mysql".to_string()
-//! #     };
-//! #     my::Opts::from_url(&*url).unwrap()
-//! # }
+//! let pool = Pool::new(get_opts())?;
 //!
-//! fn main() {
-//! #   let opts = get_opts();
-//! #   if opts.get_tcp_port() == 3307 && opts.get_pass() == Some("password") {
-//!     // See docs on the `OptsBuilder`'s methods for the list of options available via URL.
-//!     let pool = my::Pool::new("mysql://root:password@localhost:3307/mysql").unwrap();
-//! #   }
-//! #   let pool = my::Pool::new_manual(1, 1, opts).unwrap();
+//! let mut conn = pool.get_conn()?;
+//! // Let's create payment table.
+//! // Unwrap just to make sure no error happened.
+//! conn.query_drop(r"CREATE TEMPORARY TABLE payment (
+//!                      customer_id int not null,
+//!                      amount int not null,
+//!                      account_name text
+//!                  )")?;
 //!
-//!     let mut conn = pool.get_conn().unwrap();
-//!     // Let's create payment table.
-//!     // Unwrap just to make sure no error happened.
-//!     conn.query_drop(r"CREATE TEMPORARY TABLE payment (
-//!                          customer_id int not null,
-//!                          amount int not null,
-//!                          account_name text
-//!                      )").unwrap();
+//! let payments = vec![
+//!     Payment { customer_id: 1, amount: 2, account_name: None },
+//!     Payment { customer_id: 3, amount: 4, account_name: Some("foo".into()) },
+//!     Payment { customer_id: 5, amount: 6, account_name: None },
+//!     Payment { customer_id: 7, amount: 8, account_name: None },
+//!     Payment { customer_id: 9, amount: 10, account_name: Some("bar".into()) },
+//! ];
 //!
-//!     let payments = vec![
-//!         Payment { customer_id: 1, amount: 2, account_name: None },
-//!         Payment { customer_id: 3, amount: 4, account_name: Some("foo".into()) },
-//!         Payment { customer_id: 5, amount: 6, account_name: None },
-//!         Payment { customer_id: 7, amount: 8, account_name: None },
-//!         Payment { customer_id: 9, amount: 10, account_name: Some("bar".into()) },
-//!     ];
+//! // Let's insert payments to the database
+//! // We also assume that no error happened in `prep`.
+//! let stmt = conn.prep(r"INSERT INTO
+//!                        payment (customer_id, amount, account_name)
+//!                        VALUES (:customer_id, :amount, :account_name)")?;
 //!
-//!     // Let's insert payments to the database
-//!     // We also assume that no error happened in `prep`.
-//!     let stmt = conn.prep(r"INSERT INTO
-//!                            payment (customer_id, amount, account_name)
-//!                            VALUES (:customer_id, :amount, :account_name)")
-//!         .unwrap();
-//!     for p in payments.iter() {
-//!         // `execute` takes ownership of `params`, so we'll pass account name by reference.
-//!         // Unwrap each result just to make sure no errors happened.
-//!         conn.exec_drop(&stmt, params! {
-//!             "customer_id" => p.customer_id,
-//!             "amount" => p.amount,
-//!             "account_name" => &p.account_name,
-//!         }).unwrap();
-//!     }
-//!
-//!     // Let's select payments from database
-//!     let selected_payments: Vec<Payment> = conn
-//!         .query_map("SELECT customer_id, amount, account_name from payment", |row| {
-//!             // ⚠️ Note that from_row will panic if you don't follow your schema
-//!             let (customer_id, amount, account_name) = my::from_row(row);
-//!             Payment { customer_id, amount, account_name }
-//!         })
-//!         .unwrap();
-//!
-//!     // Let's make sure, that `payments` equals to `selected_payments`.
-//!     // Mysql gives no guaranties on order of returned rows
-//!     // without `ORDER BY`, so assume we are lucky.
-//!     assert_eq!(payments, selected_payments);
-//!     println!("Yay!");
+//! for p in &payments {
+//!     // `execute` takes ownership of `params`, so we'll pass account name by reference.
+//!     conn.exec_drop(&stmt, params! {
+//!         "customer_id" => p.customer_id,
+//!         "amount" => p.amount,
+//!         "account_name" => &p.account_name,
+//!     })?;
 //! }
-//! # main();
-//! # }
+//!
+//! // Let's select payments from database
+//! let selected_payments: Vec<Payment> = conn
+//!     .query_map("SELECT customer_id, amount, account_name from payment", |row| {
+//!         let (customer_id, amount, account_name) = from_row(row);
+//!         Payment { customer_id, amount, account_name }
+//!     })?;
+//!
+//! // Let's make sure, that `payments` equals to `selected_payments`.
+//! // Mysql gives no guaranties on order of returned rows
+//! // without `ORDER BY`, so assume we are lucky.
+//! assert_eq!(payments, selected_payments);
+//! println!("Yay!");
+//! # });
 //! ```
+//!
+//! ## API Documentation
+//!
+//! Please refer to the [generated docs].
+//!
+//! ## Basic structures
+//!
+//! ### `Opts`
+//!
+//! This structure holds server host name, client username/password and other settings,
+//! that controls client behavior.
+//!
+//! #### URL-based connection string
+//!
+//! Note, that this crate offers URL-based connection string as a source of an `Opts` instance.
+//! URL schema must be `mysql`. Host, port and credentials, as well as query parameters,
+//! should be given in accordance with the RFC 3986.
+//!
+//! Examples:
+//!
+//! ```rust
+//! # mysql::doctest_wrapper!(__result, {
+//! # use mysql::Opts;
+//! let _ = Opts::from_url("mysql://localhost/some_db")?;
+//! let _ = Opts::from_url("mysql://user:pass%20word@some_host:3307/some_db?")?;
+//! # });
+//! ```
+//!
+//! Supported URL parameters (for the meaning of each field please refer to the docs on `Opts`
+//! structure in the create API docs):
+//!
+//! *   `prefer_socket: true | false` - defines the value of the same field in the `Opts` structure;
+//! *   `tcp_keepalive_time_ms: u32` - defines the value (in milliseconds)
+//!     of the `tcp_keepalive_time` field in the `Opts` structure;
+//! *   `tcp_connect_timeout_ms: u64` - defines the value (in milliseconds)
+//!     of the `tcp_connect_timeout` field in the `Opts` structure;
+//! *   `stmt_cache_size: u32` - defines the value of the same field in the `Opts` structure;
+//! *   `compress` - defines the value of the same field in the `Opts` structure.
+//!     Supported value are:
+//!     *  `true` - enables compression with the default compression level;
+//!     *  `fast` - enables compression with "fast" compression level;
+//!     *  `best` - enables compression with "best" compression level;
+//!     *  `1`..`9` - enables compression with the given compression level.
+//! *   `socket` - socket path on UNIX, or pipe name on Windows.
+//!
+//! ### `OptsBuilder`
+//!
+//! It's a convenient builder for the `Opts` structure. It defines setters for fields
+//! of the `Opts` structure.
+//!
+//! ### `Conn`
+//!
+//! This structure represents an active MySql connection. It also holds statement cache
+//! and metadata for the last result set.
+//!
+//! ### `Transaction`
+//!
+//! It's a simple wrapper on top of a routine, that starts with `START TRANSACTION`
+//! and ends with `COMMIT` or `ROLBACK`.
+//!
+//! ### `Pool`
+//!
+//! It's a reference to a connection pool, that can be cloned and shared between threads.
+//!
+//! ### `Statement`
+//!
+//! Statement, actually, is just an identifier coupled with statement metadata, i.e an information
+//! about its parameters and columns. Internally the `Statement` structure also holds additional
+//! data required to support named parameters (see bellow).
+//!
+//! ### `Value`
+//!
+//! This enumeration represents the raw value of a MySql cell. Library offers conversion between
+//! `Value` and different rust types via `FromValue` trait described below.
+//!
+//! #### `FromValue` trait
+//!
+//! This trait is reexported from **mysql_common** create. Please refer to its
+//! [crate docs][mysql_common docs] for the list of supported conversions.
+//!
+//! Trait offers conversion in two flavours:
+//!
+//! *   `from_value(Value) -> T` - convenient, but panicking conversion.
+//!
+//!     Note, that for any variant of `Value` there exist a type, that fully covers its domain,
+//!     i.e. for any variant of `Value` there exist `T: FromValue` such that `from_value` will never
+//!     panic. This means, that if your database schema is known, than it's possible to write your
+//!     application using only `from_value` with no fear of runtime panic.
+//!
+//! *   `from_value_opt(Value) -> Option<T>` - non-panicking, but less convenient conversion.
+//!
+//!     This function is useful to probe conversion in cases, where source database schema
+//!     is unknown.
+//!
+//! ### `Row`
+//!
+//! Internally `Row` is a vector of `Value`s, that also allows indexing by a column name/offset,
+//! and stores row metadata. Library offers conversion between `Row` and sequences of Rust types
+//! via `FromRow` trait described below.
+//!
+//! #### `FromRow` trait
+//!
+//! This trait is reexported from **mysql_common** create. Please refer to its
+//! [crate docs][mysql_common docs] for the list of supported conversions.
+//!
+//! This conversion is based on the `FromValue` and so comes in two similar flavours:
+//!
+//! *   `from_row(Row) -> T` - same as `from_value`, but for rows;
+//! *   `from_row_opt(Row) -> Option<T>` - same as `from_value_opt`, but for rows.
+//!
+//! ### `Params`
+//!
+//! Represents parameters of a prepared statement, but this type won't appear directly in your code
+//! because binary protocol API will ask for `T: Into<Params>`, where `Into<Params>` is implemented:
+//!
+//! *    for tuples of `Into<Value>` types up to arity 12, where empty tuple is for statements
+//!      without parameters, and unary tuple requires extra comma (e.g. `(val,)`);
+//! *    for `Vec<T: Into<Value>>` for cases, when your statement takes more than 12 parameters;
+//! *    for named parameters representation (the value of the `params!` macro, described below).
+//!
+//! **Note:** Please refer to the [**mysql_common** crate docs][mysql_common docs] for the list
+//! of types, that implements `Into<Value>`.
+//!
+//! #### `Serialized`, `Deserialized`
+//!
+//! Wrapper structures for cases, when you need to provide a value for a JSON cell,
+//! or when you need to parse JSON cell as a struct.
+//!
+//! ```rust
+//! # #[macro_use] extern crate serde_derive;
+//! # mysql::doctest_wrapper!(__result, {
+//! # use mysql::*;
+//! #[derive(Debug, PartialEq, Serialize, Deserialize)]
+//! struct Example {
+//!     foo: u32,
+//! }
+//!
+//! let value = Value::from(Serialized(Example { foo: 42 }));
+//! assert_eq!(value, Value::from(r#"{"foo":42}"#));
+//!
+//! let structure: Deserialized<Example> = from_value(value);
+//! assert_eq!(structure, Deserialized(Example { foo: 42 }));
+//! # });
+//! ```
+//!
+//! ### `QueryResult`
+//!
+//! It's an iterator over rows of a query result with support of multi-result sets. It's intended
+//! for cases when you need full control during result set iteration. For other cases `Conn`
+//! provides a set of methods that will immediately costume the first result set and drop everything
+//! else.
+//!
+//! This iterator is lazy so it won't read the result from server until you iterate over it.
+//! MySql protocol is strictly sequential, so `Conn` will be mutably borrowed until the result
+//! is fully consumed.
+//!
+//! ## Text protocol
+//!
+//! MySql text protocol is implemented in the set of `Conn::query*` methods. It's useful when your
+//! query doesn't have parameters.
+//!
+//! **Note:** All values of a text protocol result set will be encoded as strings by the server,
+//! so `from_value` conversion may lead to additional parsing costs.
+//!
+//! Examples:
+//!
+//! ```rust
+//! # mysql::doctest_wrapper!(__result, {
+//! # use mysql::*;
+//! # use mysql::prelude::*;
+//! let pool = Pool::new(get_opts())?;
+//! let val = pool.get_conn()?.query_first("SELECT POW(2, 16)")?;
+//!
+//! assert_eq!(val, Some(Value::Bytes("65536".as_bytes().to_vec())));
+//! # });
+//! ```
+//!
+//! ## Binary protocol
+//!
+//! MySql binary protocol is implemented in the set of `Conn::exec*` methods. It's useful when your
+//! query have parameters. MySql uses `?` symbol as a parameter placeholder and it's only possible
+//! to use parameters where a single MySql value is expected. For example:
+//!
+//! ```rust
+//! # mysql::doctest_wrapper!(__result, {
+//! # use mysql::*;
+//! # use mysql::prelude::*;
+//! let pool = Pool::new(get_opts())?;
+//! let val = pool.get_conn()?.exec_first("SELECT POW(?, ?)", (2, 16))?;
+//!
+//! assert_eq!(val, Some(Value::UInt(65536)));
+//! # });
+//! ```
+//!
+//! ### Statements
+//!
+//! In mysql each prepared statement belongs to a particular connection and can't be executed
+//! on another connection. Trying to do so will lead to an error. Library won't tie statement
+//! to a connection in any way, but one can look on to the connection id, that is stored
+//! in the `Statement` structure.
+//!
+//! ```rust
+//! # mysql::doctest_wrapper!(__result, {
+//! # use mysql::*;
+//! # use mysql::prelude::*;
+//! let pool = Pool::new(get_opts())?;
+//!
+//! let mut conn_1 = pool.get_conn()?;
+//! let mut conn_2 = pool.get_conn()?;
+//!
+//! let stmt_1 = conn_1.prep("SELECT ?")?;
+//!
+//! assert!(stmt_1.connection_id() == conn_1.connection_id());
+//! assert!(stmt_1.connection_id() != conn_2.connection_id());
+//!
+//! assert!(conn_1.exec_drop(&stmt_1, ("foo",)).is_ok());
+//! assert!(conn_2.exec_drop(&stmt_1, ("foo",)).is_err());
+//! # });
+//! ```
+//!
+//! ### Statement cache
+//!
+//! `Conn` will manage the cache of prepared statements on the client side, so subsequent calls
+//! to prepare with the same statement won't lead to a client-server roundtrip. Cache size
+//! for each connection is determined by the `stmt_cache_size` field of the `Opts` structure.
+//! Statements, that are out of this boundary will be closed in LRU order.
+//!
+//! Statement cache is completely disabled if `stmt_cache_size` is zero.
+//!
+//! **Caveats:**
+//!
+//! *   disabled statement cache means, that you have to close statements yourself using
+//!     `Conn::close`, or they'll exhaust server limits/resources;
+//!
+//! *   you should be aware of the [`max_prepared_stmt_count`][max_prepared_stmt_count]
+//!     option of the MySql server. If the number of active connections times the value
+//!     of `stmt_cache_size` is greater, than you could receive an error while prepareing
+//!     another statement.
+//!
+//! ### Named parameters
+//!
+//! MySql itself doesn't have named parameters support, so it's implemented on the client side.
+//! One should use `:name` as a placeholder syntax for a named parameter.
+//!
+//! Named parameters may be repeated within the statement, e.g `SELECT :foo :foo` will require
+//! a single named parameter `foo` that will be repeated on the corresponding positions during
+//! statement execution.
+//!
+//! One should use the `params!` macro to build a parameters for execution.
+//!
+//! **Note:** Positional and named parameters can't be mixed within the single statement.
+//!
+//! Examples:
+//!
+//! ```rust
+//! # mysql::doctest_wrapper!(__result, {
+//! # use mysql::*;
+//! # use mysql::prelude::*;
+//! let pool = Pool::new(get_opts())?;
+//!
+//! let mut conn = pool.get_conn()?;
+//! let stmt = conn.prep("SELECT :foo, :bar, :foo")?;
+//!
+//! let foo = 42;
+//!
+//! let val_13 = conn.exec_first(&stmt, params! { "foo" => 13, "bar" => foo })?.unwrap();
+//! // Short syntax is available when param name is the same as variable name:
+//! let val_42 = conn.exec_first(&stmt, params! { foo, "bar" => 13 })?.unwrap();
+//!
+//! assert_eq!((foo, 13, foo), val_42);
+//! assert_eq!((13, foo, 13), val_13);
+//! # });
+//! ```
+//!
+//! [generated docs]: https://docs.rs/mysql
+//! [mysql_common docs]: https://docs.rs/mysql_common
+//! [max_prepared_stmt_count]: https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_prepared_stmt_count
+//!
 
 #![crate_name = "mysql"]
 #![crate_type = "rlib"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,11 +47,14 @@
 //!     account_name: Option<String>,
 //! }
 //!
-//! let pool = Pool::new(get_opts())?;
+//! let url = "mysql://root:password@localhost:3307/db_name";
+//! # let url = get_opts();
+//!
+//! let pool = Pool::new(url)?;
 //!
 //! let mut conn = pool.get_conn()?;
-//! // Let's create payment table.
-//! // Unwrap just to make sure no error happened.
+//!
+//! // Let's create a table for payments.
 //! conn.query_drop(r"CREATE TEMPORARY TABLE payment (
 //!                      customer_id int not null,
 //!                      amount int not null,
@@ -66,8 +69,10 @@
 //!     Payment { customer_id: 9, amount: 10, account_name: Some("bar".into()) },
 //! ];
 //!
-//! // Let's insert payments to the database
-//! // We also assume that no error happened in `prep`.
+//! // Now let's insert payments to the database
+//!
+//! // First of all we'll prepare the statement to avoid
+//! // statement cache lookup (see the "statement cache" section)
 //! let stmt = conn.prep(r"INSERT INTO
 //!                        payment (customer_id, amount, account_name)
 //!                        VALUES (:customer_id, :amount, :account_name)")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 //!
 //! # fn main() {
 //! use mysql as my;
+//! use my::prelude::*;
 //!
 //! #[derive(Debug, PartialEq, Eq)]
 //! struct Payment {
@@ -47,13 +48,14 @@
 //! #   }
 //! #   let pool = my::Pool::new_manual(1, 1, opts).unwrap();
 //!
+//!     let mut conn = pool.get_conn().unwrap();
 //!     // Let's create payment table.
 //!     // Unwrap just to make sure no error happened.
-//!     pool.prep_exec(r"CREATE TEMPORARY TABLE payment (
+//!     conn.query_drop(r"CREATE TEMPORARY TABLE payment (
 //!                          customer_id int not null,
 //!                          amount int not null,
 //!                          account_name text
-//!                      )", ()).unwrap();
+//!                      )").unwrap();
 //!
 //!     let payments = vec![
 //!         Payment { customer_id: 1, amount: 2, account_name: None },
@@ -64,44 +66,33 @@
 //!     ];
 //!
 //!     // Let's insert payments to the database
-//!     // We will use into_iter() because we do not need to map Stmt to anything else.
-//!     // Also we assume that no error happened in `prepare`.
-//!     for mut stmt in pool.prepare(r"INSERT INTO payment
-//!                                        (customer_id, amount, account_name)
-//!                                    VALUES
-//!                                        (:customer_id, :amount, :account_name)").into_iter() {
-//!         for p in payments.iter() {
-//!             // `execute` takes ownership of `params` so we pass account name by reference.
-//!             // Unwrap each result just to make sure no errors happened.
-//!             stmt.execute(params!{
-//!                 "customer_id" => p.customer_id,
-//!                 "amount" => p.amount,
-//!                 "account_name" => &p.account_name,
-//!             }).unwrap();
-//!         }
+//!     // We also assume that no error happened in `prep`.
+//!     let stmt = conn.prep(r"INSERT INTO
+//!                            payment (customer_id, amount, account_name)
+//!                            VALUES (:customer_id, :amount, :account_name)")
+//!         .unwrap();
+//!     for p in payments.iter() {
+//!         // `execute` takes ownership of `params`, so we'll pass account name by reference.
+//!         // Unwrap each result just to make sure no errors happened.
+//!         conn.exec_drop(&stmt, params! {
+//!             "customer_id" => p.customer_id,
+//!             "amount" => p.amount,
+//!             "account_name" => &p.account_name,
+//!         }).unwrap();
 //!     }
 //!
 //!     // Let's select payments from database
-//!     let selected_payments: Vec<Payment> =
-//!     pool.prep_exec("SELECT customer_id, amount, account_name from payment", ())
-//!     .map(|result| { // In this closure we will map `QueryResult` to `Vec<Payment>`
-//!         // `QueryResult` is iterator over `MyResult<row, err>` so first call to `map`
-//!         // will map each `MyResult` to contained `row` (no proper error handling)
-//!         // and second call to `map` will map each `row` to `Payment`
-//!         result.map(|x| x.unwrap()).map(|row| {
+//!     let selected_payments: Vec<Payment> = conn
+//!         .query_map("SELECT customer_id, amount, account_name from payment", |row| {
 //!             // ⚠️ Note that from_row will panic if you don't follow your schema
 //!             let (customer_id, amount, account_name) = my::from_row(row);
-//!             Payment {
-//!                 customer_id: customer_id,
-//!                 amount: amount,
-//!                 account_name: account_name,
-//!             }
-//!         }).collect() // Collect payments so now `QueryResult` is mapped to `Vec<Payment>`
-//!     }).unwrap(); // Unwrap `Vec<Payment>`
+//!             Payment { customer_id, amount, account_name }
+//!         })
+//!         .unwrap();
 //!
-//!     // Now make sure that `payments` equals to `selected_payments`.
-//!     // Mysql gives no guaranties on order of returned rows without `ORDER BY`
-//!     // so assume we are lukky.
+//!     // Let's make sure, that `payments` equals to `selected_payments`.
+//!     // Mysql gives no guaranties on order of returned rows
+//!     // without `ORDER BY`, so assume we are lucky.
 //!     assert_eq!(payments, selected_payments);
 //!     println!("Yay!");
 //! }
@@ -130,11 +121,10 @@ pub use crate::myc::time;
 /// Reexport of `uuid` crate.
 pub use crate::myc::uuid;
 
-// Until `macro_reexport` stabilisation.
-
 mod conn;
 pub mod error;
 mod io;
+mod queryable;
 
 #[doc(inline)]
 pub use crate::myc::constants as consts;
@@ -144,13 +134,13 @@ pub use crate::conn::local_infile::{LocalInfile, LocalInfileHandler};
 #[doc(inline)]
 pub use crate::conn::opts::SslOpts;
 #[doc(inline)]
-pub use crate::conn::opts::{Opts, OptsBuilder};
+pub use crate::conn::opts::{Opts, OptsBuilder, DEFAULT_STMT_CACHE_SIZE};
 #[doc(inline)]
 pub use crate::conn::pool::{Pool, PooledConn};
 #[doc(inline)]
 pub use crate::conn::query_result::QueryResult;
 #[doc(inline)]
-pub use crate::conn::stmt::Stmt;
+pub use crate::conn::stmt::Statement;
 #[doc(inline)]
 pub use crate::conn::transaction::{IsolationLevel, Transaction};
 #[doc(inline)]
@@ -176,26 +166,93 @@ pub use crate::myc::value::Value;
 
 pub mod prelude {
     #[doc(inline)]
-    pub use crate::conn::GenericConnection;
-    #[doc(inline)]
     pub use crate::myc::row::convert::FromRow;
     #[doc(inline)]
     pub use crate::myc::row::ColumnIndex;
     #[doc(inline)]
     pub use crate::myc::value::convert::{ConvIr, FromValue, ToValue};
+    #[doc(inline)]
+    pub use crate::queryable::{AsStatement, Queryable};
 }
 
 #[doc(inline)]
 pub use crate::myc::params;
 
+#[doc(hidden)]
+#[macro_export]
+macro_rules! def_database_url {
+    () => {
+        if let Ok(url) = std::env::var("DATABASE_URL") {
+            let opts = $crate::Opts::from_url(&url).expect("DATABASE_URL invalid");
+            if opts
+                .get_db_name()
+                .expect("a database name is required")
+                .is_empty()
+            {
+                panic!("database name is empty");
+            }
+            url
+        } else {
+            "mysql://root:password@127.0.0.1:3307/mysql".into()
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! def_get_opts {
+    () => {
+        pub fn test_ssl() -> bool {
+            let ssl = std::env::var("SSL").ok().unwrap_or("false".into());
+            ssl == "true" || ssl == "1"
+        }
+
+        pub fn test_compression() -> bool {
+            let compress = std::env::var("COMPRESS").ok().unwrap_or("false".into());
+            compress == "true" || compress == "1"
+        }
+
+        pub fn get_opts() -> $crate::OptsBuilder {
+            let database_url = $crate::def_database_url!();
+            let mut builder = $crate::OptsBuilder::from_opts(&*database_url);
+            builder.init(vec!["SET GLOBAL sql_mode = 'TRADITIONAL'"]);
+            if test_compression() {
+                builder.compress(Some(Default::default()));
+            }
+            if test_ssl() {
+                builder.prefer_socket(false);
+                let mut ssl_opts = $crate::SslOpts::default();
+                ssl_opts.set_danger_skip_domain_validation(true);
+                ssl_opts.set_danger_accept_invalid_certs(true);
+                builder.ssl_opts(ssl_opts);
+            }
+            builder
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! doctest_wrapper {
+    ($body:block) => {
+        fn main() {
+            $crate::def_get_opts!();
+            $body;
+        }
+    };
+    (__result, $body:block) => {
+        fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+            $crate::def_get_opts!();
+            Ok($body)
+        }
+    };
+}
+
 #[cfg(test)]
 mod test_misc {
     use lazy_static::lazy_static;
 
-    use std::env;
-
-    use crate::conn::opts::{Opts, OptsBuilder};
-    use crate::SslOpts;
+    use crate::{def_database_url, def_get_opts};
 
     #[allow(dead_code)]
     fn error_should_implement_send_and_sync() {
@@ -204,46 +261,8 @@ mod test_misc {
     }
 
     lazy_static! {
-        pub static ref DATABASE_URL: String = {
-            if let Ok(url) = env::var("DATABASE_URL") {
-                let opts = Opts::from_url(&url).expect("DATABASE_URL invalid");
-                if opts
-                    .get_db_name()
-                    .expect("a database name is required")
-                    .is_empty()
-                {
-                    panic!("database name is empty");
-                }
-                url
-            } else {
-                "mysql://root:password@127.0.0.1:3307/mysql".into()
-            }
-        };
+        pub static ref DATABASE_URL: String = def_database_url!();
     }
 
-    pub fn get_opts() -> OptsBuilder {
-        let mut builder = OptsBuilder::from_opts(&**DATABASE_URL);
-        builder.init(vec!["SET GLOBAL sql_mode = 'TRADITIONAL'"]);
-        if test_compression() {
-            builder.compress(Some(Default::default()));
-        }
-        if test_ssl() {
-            builder.prefer_socket(false);
-            let mut ssl_opts = SslOpts::default();
-            ssl_opts.set_danger_skip_domain_validation(true);
-            ssl_opts.set_danger_accept_invalid_certs(true);
-            builder.ssl_opts(ssl_opts);
-        }
-        builder
-    }
-
-    pub fn test_ssl() -> bool {
-        let ssl = env::var("SSL").ok().unwrap_or("false".into());
-        ssl == "true" || ssl == "1"
-    }
-
-    pub fn test_compression() -> bool {
-        let compress = env::var("COMPRESS").ok().unwrap_or("false".into());
-        compress == "true" || compress == "1"
-    }
+    def_get_opts!();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -761,9 +761,7 @@ macro_rules! def_get_opts {
                 let ssl_opts = $crate::SslOpts::default()
                     .with_danger_skip_domain_validation(true)
                     .with_danger_accept_invalid_certs(true);
-                builder = builder
-                    .prefer_socket(false)
-                    .ssl_opts(ssl_opts);
+                builder = builder.prefer_socket(false).ssl_opts(ssl_opts);
             }
             builder
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,3 @@
-//! # rust-mysql-simple
-//!
-//! **Crate name:** mysql
-//!
 //! This create offers:
 //!
 //! *   MySql database driver in pure rust;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -517,7 +517,7 @@
 //!
 //! ## Binary protocol and prepared statements.
 //!
-//! MySql binary protocol is implemented in `prep, `close` and the set of `exec*` methods,
+//! MySql binary protocol is implemented in `prep`, `close` and the set of `exec*` methods,
 //! defined on the [`Queryable`](#queryable) trait. Prepared statements is the only way to
 //! pass rust value to the MySql server. MySql uses `?` symbol as a parameter placeholder
 //! and it's only possible to use parameters where a single MySql value is expected.

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use crate::{prelude::FromRow, from_row, Params, QueryResult, Result, Statement};
+use crate::{from_row, prelude::FromRow, Params, QueryResult, Result, Statement};
 
 pub trait AsStatement {
     fn as_statement<Q: Queryable>(&self, queryable: &mut Q) -> Result<Cow<'_, Statement>>;
@@ -74,7 +74,7 @@ pub trait Queryable {
         Self: Sized,
         S: AsStatement,
         P: Into<Params>,
-        I: IntoIterator<Item=P>,
+        I: IntoIterator<Item = P>,
     {
         let stmt = stmt.as_statement(self)?;
         for params in params {

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -1,3 +1,11 @@
+// Copyright (c) 2020 rust-mysql-common contributors
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
 use std::borrow::Cow;
 
 use crate::{from_row, prelude::FromRow, Params, QueryResult, Result, Statement};

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use crate::{prelude::FromRow, Params, QueryResult, Result, Statement};
+use crate::{prelude::FromRow, from_row, Params, QueryResult, Result, Statement};
 
 pub trait AsStatement {
     fn as_statement<Q: Queryable>(&self, queryable: &mut Q) -> Result<Cow<'_, Statement>>;
@@ -8,20 +8,20 @@ pub trait AsStatement {
 
 /// Queryable object.
 pub trait Queryable {
-    fn query_iter<T: AsRef<str>>(&mut self, query: T) -> Result<QueryResult<'_>>;
+    fn query_iter<Q: AsRef<str>>(&mut self, query: Q) -> Result<QueryResult<'_>>;
 
-    fn query<T, U>(&mut self, query: T) -> Result<Vec<U>>
+    fn query<T, Q>(&mut self, query: Q) -> Result<Vec<T>>
     where
-        T: AsRef<str>,
-        U: FromRow,
+        Q: AsRef<str>,
+        T: FromRow,
     {
-        self.query_map(query, crate::from_row)
+        self.query_map(query, from_row)
     }
 
-    fn query_first<T, U>(&mut self, query: T) -> Result<Option<U>>
+    fn query_first<T, Q>(&mut self, query: Q) -> Result<Option<T>>
     where
-        T: AsRef<str>,
-        U: FromRow,
+        Q: AsRef<str>,
+        T: FromRow,
     {
         self.query_iter(query)?
             .next()
@@ -29,10 +29,11 @@ pub trait Queryable {
             .transpose()
     }
 
-    fn query_map<F, T, U>(&mut self, query: T, mut f: F) -> Result<Vec<U>>
+    fn query_map<T, F, Q, U>(&mut self, query: Q, mut f: F) -> Result<Vec<U>>
     where
-        T: AsRef<str>,
-        F: FnMut(crate::Row) -> U,
+        Q: AsRef<str>,
+        T: FromRow,
+        F: FnMut(T) -> U,
     {
         self.query_fold(query, Vec::new(), |mut acc, row| {
             acc.push(f(row));
@@ -40,109 +41,24 @@ pub trait Queryable {
         })
     }
 
-    fn query_fold<F, T, U>(&mut self, query: T, init: U, mut f: F) -> Result<U>
+    fn query_fold<T, F, Q, U>(&mut self, query: Q, init: U, mut f: F) -> Result<U>
     where
-        T: AsRef<str>,
-        F: FnMut(U, crate::Row) -> U,
+        Q: AsRef<str>,
+        T: FromRow,
+        F: FnMut(U, T) -> U,
     {
         self.query_iter(query)?
-            .try_fold(init, |acc, row| row.map(|row| f(acc, row)))
+            .map(|row| row.map(from_row::<T>))
+            .try_fold(init, |acc, row: Result<T>| row.map(|row| f(acc, row)))
     }
 
-    fn query_drop<T>(&mut self, query: T) -> Result<()>
+    fn query_drop<Q>(&mut self, query: Q) -> Result<()>
     where
-        T: AsRef<str>,
+        Q: AsRef<str>,
     {
         self.query_iter(query).map(drop)
     }
 
-    /// Implements binary protocol of mysql server.
-    ///
-    /// Prepares mysql statement on `Conn`. [`Stmt`](struct.Stmt.html) will
-    /// borrow `Conn` until the end of its scope.
-    ///
-    /// This call will take statement from cache if has been prepared on this connection.
-    ///
-    /// ### JSON caveats
-    ///
-    /// For the following statement you will get somewhat unexpected result `{"a": 0}`, because
-    /// booleans in mysql binary protocol is `TINYINT(1)` and will be interpreted as `0`:
-    ///
-    /// ```ignore
-    /// pool.prep_exec(r#"SELECT JSON_REPLACE('{"a": true}', '$.a', ?)"#, (false,));
-    /// ```
-    ///
-    /// You should wrap such parameters to a proper json value. For example:
-    ///
-    /// ```ignore
-    /// pool.prep_exec(r#"SELECT JSON_REPLACE('{"a": true}', '$.a', ?)"#, (Value::Bool(false),));
-    /// ```
-    ///
-    /// ### Named parameters support
-    ///
-    /// `prepare` supports named parameters in form of `:named_param_name`. Allowed characters for
-    /// parameter name are `[a-z_]`. Named parameters will be converted to positional before actual
-    /// call to prepare so `SELECT :a-:b, :a*:b` is actually `SELECT ?-?, ?*?`.
-    ///
-    /// ```
-    /// # #[macro_use] extern crate mysql; fn main() {
-    /// # use mysql::prelude::*;
-    /// # use mysql::{Pool, Opts, OptsBuilder, from_row};
-    /// # use mysql::Error::DriverError;
-    /// # use mysql::DriverError::MixedParams;
-    /// # use mysql::DriverError::MissingNamedParameter;
-    /// # use mysql::DriverError::NamedParamsForPositionalQuery;
-    /// # fn get_opts() -> Opts {
-    /// #     let url = if let Ok(url) = std::env::var("DATABASE_URL") {
-    /// #         let opts = Opts::from_url(&url).expect("DATABASE_URL invalid");
-    /// #         if opts.get_db_name().expect("a database name is required").is_empty() {
-    /// #             panic!("database name is empty");
-    /// #         }
-    /// #         url
-    /// #     } else {
-    /// #         "mysql://root:password@127.0.0.1:3307/mysql".to_string()
-    /// #     };
-    /// #     Opts::from_url(&*url).unwrap()
-    /// # }
-    /// # let opts = get_opts();
-    /// # let pool = Pool::new(opts).unwrap();
-    /// # let mut conn = pool.get_conn().unwrap();
-    /// // Names could be repeated
-    /// conn.exec_iter("SELECT :a+:b, :a * :b, ':c'", params!{"a" => 2, "b" => 3}).map(|mut result| {
-    ///     let row = result.next().unwrap().unwrap();
-    ///     assert_eq!((5, 6, String::from(":c")), from_row(row));
-    /// }).unwrap();
-    ///
-    /// // You can call named statement with positional parameters
-    /// conn.exec_iter("SELECT :a+:b, :a*:b", (2, 3, 2, 3)).map(|mut result| {
-    ///     let row = result.next().unwrap().unwrap();
-    ///     assert_eq!((5, 6), from_row(row));
-    /// }).unwrap();
-    ///
-    /// // You must pass all named parameters for statement
-    /// let err = conn.exec_drop("SELECT :name", params!{"another_name" => 42}).unwrap_err();
-    /// match err {
-    ///     DriverError(e) => {
-    ///         assert_eq!(MissingNamedParameter("name".into()), e);
-    ///     }
-    ///     _ => unreachable!(),
-    /// }
-    ///
-    /// // You can't call positional statement with named parameters
-    /// let err = conn.exec_drop("SELECT ?", params!{"first" => 42}).unwrap_err();
-    /// match err {
-    ///     DriverError(e) => assert_eq!(NamedParamsForPositionalQuery, e),
-    ///     _ => unreachable!(),
-    /// }
-    ///
-    /// // You can't mix named and positional parameters
-    /// let err = conn.prep("SELECT :a, ?").unwrap_err();
-    /// match err {
-    ///     DriverError(e) => assert_eq!(MixedParams, e),
-    ///     _ => unreachable!(),
-    /// }
-    /// # }
-    /// ```
     fn prep<Q: AsRef<str>>(&mut self, query: Q) -> Result<crate::Statement>;
 
     /// This function will close the given statement on the server side.
@@ -153,7 +69,22 @@ pub trait Queryable {
         S: AsStatement,
         P: Into<Params>;
 
-    fn exec<S, P, T>(&mut self, stmt: S, params: P) -> Result<Vec<T>>
+    fn exec_batch<S, P, I>(&mut self, stmt: S, params: I) -> Result<()>
+    where
+        Self: Sized,
+        S: AsStatement,
+        P: Into<Params>,
+        I: IntoIterator<Item=P>,
+    {
+        let stmt = stmt.as_statement(self)?;
+        for params in params {
+            self.exec_drop(stmt.as_ref(), params)?;
+        }
+
+        Ok(())
+    }
+
+    fn exec<T, S, P>(&mut self, stmt: S, params: P) -> Result<Vec<T>>
     where
         S: AsStatement,
         P: Into<Params>,
@@ -162,7 +93,7 @@ pub trait Queryable {
         self.exec_map(stmt, params, crate::from_row)
     }
 
-    fn exec_first<S, P, T>(&mut self, stmt: S, params: P) -> Result<Option<T>>
+    fn exec_first<T, S, P>(&mut self, stmt: S, params: P) -> Result<Option<T>>
     where
         S: AsStatement,
         P: Into<Params>,
@@ -174,11 +105,12 @@ pub trait Queryable {
             .transpose()
     }
 
-    fn exec_map<S, P, F, T>(&mut self, stmt: S, params: P, mut f: F) -> Result<Vec<T>>
+    fn exec_map<T, S, P, F, U>(&mut self, stmt: S, params: P, mut f: F) -> Result<Vec<U>>
     where
         S: AsStatement,
         P: Into<Params>,
-        F: FnMut(crate::Row) -> T,
+        T: FromRow,
+        F: FnMut(T) -> U,
     {
         self.exec_fold(stmt, params, Vec::new(), |mut acc, row| {
             acc.push(f(row));
@@ -186,14 +118,15 @@ pub trait Queryable {
         })
     }
 
-    fn exec_fold<S, P, T, F>(&mut self, stmt: S, params: P, init: T, mut f: F) -> Result<T>
+    fn exec_fold<T, S, P, U, F>(&mut self, stmt: S, params: P, init: U, mut f: F) -> Result<U>
     where
         S: AsStatement,
         P: Into<Params>,
-        F: FnMut(T, crate::Row) -> T,
+        T: FromRow,
+        F: FnMut(U, T) -> U,
     {
         let mut result = self.exec_iter(stmt, params)?;
-        let output = result.try_fold(init, |init, row| row.map(|row| f(init, row)));
+        let output = result.try_fold(init, |init, row| row.map(|row| f(init, from_row(row))));
         output
     }
 

--- a/src/queryable.rs
+++ b/src/queryable.rs
@@ -1,0 +1,207 @@
+use std::borrow::Cow;
+
+use crate::{prelude::FromRow, Params, QueryResult, Result, Statement};
+
+pub trait AsStatement {
+    fn as_statement<Q: Queryable>(&self, queryable: &mut Q) -> Result<Cow<'_, Statement>>;
+}
+
+/// Queryable object.
+pub trait Queryable {
+    fn query_iter<T: AsRef<str>>(&mut self, query: T) -> Result<QueryResult<'_>>;
+
+    fn query<T, U>(&mut self, query: T) -> Result<Vec<U>>
+    where
+        T: AsRef<str>,
+        U: FromRow,
+    {
+        self.query_map(query, crate::from_row)
+    }
+
+    fn query_first<T, U>(&mut self, query: T) -> Result<Option<U>>
+    where
+        T: AsRef<str>,
+        U: FromRow,
+    {
+        self.query_iter(query)?
+            .next()
+            .map(|row| row.map(crate::from_row))
+            .transpose()
+    }
+
+    fn query_map<F, T, U>(&mut self, query: T, mut f: F) -> Result<Vec<U>>
+    where
+        T: AsRef<str>,
+        F: FnMut(crate::Row) -> U,
+    {
+        self.query_fold(query, Vec::new(), |mut acc, row| {
+            acc.push(f(row));
+            acc
+        })
+    }
+
+    fn query_fold<F, T, U>(&mut self, query: T, init: U, mut f: F) -> Result<U>
+    where
+        T: AsRef<str>,
+        F: FnMut(U, crate::Row) -> U,
+    {
+        self.query_iter(query)?
+            .try_fold(init, |acc, row| row.map(|row| f(acc, row)))
+    }
+
+    fn query_drop<T>(&mut self, query: T) -> Result<()>
+    where
+        T: AsRef<str>,
+    {
+        self.query_iter(query).map(drop)
+    }
+
+    /// Implements binary protocol of mysql server.
+    ///
+    /// Prepares mysql statement on `Conn`. [`Stmt`](struct.Stmt.html) will
+    /// borrow `Conn` until the end of its scope.
+    ///
+    /// This call will take statement from cache if has been prepared on this connection.
+    ///
+    /// ### JSON caveats
+    ///
+    /// For the following statement you will get somewhat unexpected result `{"a": 0}`, because
+    /// booleans in mysql binary protocol is `TINYINT(1)` and will be interpreted as `0`:
+    ///
+    /// ```ignore
+    /// pool.prep_exec(r#"SELECT JSON_REPLACE('{"a": true}', '$.a', ?)"#, (false,));
+    /// ```
+    ///
+    /// You should wrap such parameters to a proper json value. For example:
+    ///
+    /// ```ignore
+    /// pool.prep_exec(r#"SELECT JSON_REPLACE('{"a": true}', '$.a', ?)"#, (Value::Bool(false),));
+    /// ```
+    ///
+    /// ### Named parameters support
+    ///
+    /// `prepare` supports named parameters in form of `:named_param_name`. Allowed characters for
+    /// parameter name are `[a-z_]`. Named parameters will be converted to positional before actual
+    /// call to prepare so `SELECT :a-:b, :a*:b` is actually `SELECT ?-?, ?*?`.
+    ///
+    /// ```
+    /// # #[macro_use] extern crate mysql; fn main() {
+    /// # use mysql::prelude::*;
+    /// # use mysql::{Pool, Opts, OptsBuilder, from_row};
+    /// # use mysql::Error::DriverError;
+    /// # use mysql::DriverError::MixedParams;
+    /// # use mysql::DriverError::MissingNamedParameter;
+    /// # use mysql::DriverError::NamedParamsForPositionalQuery;
+    /// # fn get_opts() -> Opts {
+    /// #     let url = if let Ok(url) = std::env::var("DATABASE_URL") {
+    /// #         let opts = Opts::from_url(&url).expect("DATABASE_URL invalid");
+    /// #         if opts.get_db_name().expect("a database name is required").is_empty() {
+    /// #             panic!("database name is empty");
+    /// #         }
+    /// #         url
+    /// #     } else {
+    /// #         "mysql://root:password@127.0.0.1:3307/mysql".to_string()
+    /// #     };
+    /// #     Opts::from_url(&*url).unwrap()
+    /// # }
+    /// # let opts = get_opts();
+    /// # let pool = Pool::new(opts).unwrap();
+    /// # let mut conn = pool.get_conn().unwrap();
+    /// // Names could be repeated
+    /// conn.exec_iter("SELECT :a+:b, :a * :b, ':c'", params!{"a" => 2, "b" => 3}).map(|mut result| {
+    ///     let row = result.next().unwrap().unwrap();
+    ///     assert_eq!((5, 6, String::from(":c")), from_row(row));
+    /// }).unwrap();
+    ///
+    /// // You can call named statement with positional parameters
+    /// conn.exec_iter("SELECT :a+:b, :a*:b", (2, 3, 2, 3)).map(|mut result| {
+    ///     let row = result.next().unwrap().unwrap();
+    ///     assert_eq!((5, 6), from_row(row));
+    /// }).unwrap();
+    ///
+    /// // You must pass all named parameters for statement
+    /// let err = conn.exec_drop("SELECT :name", params!{"another_name" => 42}).unwrap_err();
+    /// match err {
+    ///     DriverError(e) => {
+    ///         assert_eq!(MissingNamedParameter("name".into()), e);
+    ///     }
+    ///     _ => unreachable!(),
+    /// }
+    ///
+    /// // You can't call positional statement with named parameters
+    /// let err = conn.exec_drop("SELECT ?", params!{"first" => 42}).unwrap_err();
+    /// match err {
+    ///     DriverError(e) => assert_eq!(NamedParamsForPositionalQuery, e),
+    ///     _ => unreachable!(),
+    /// }
+    ///
+    /// // You can't mix named and positional parameters
+    /// let err = conn.prep("SELECT :a, ?").unwrap_err();
+    /// match err {
+    ///     DriverError(e) => assert_eq!(MixedParams, e),
+    ///     _ => unreachable!(),
+    /// }
+    /// # }
+    /// ```
+    fn prep<Q: AsRef<str>>(&mut self, query: Q) -> Result<crate::Statement>;
+
+    /// This function will close the given statement on the server side.
+    fn close(&mut self, stmt: Statement) -> Result<()>;
+
+    fn exec_iter<S, P>(&mut self, stmt: S, params: P) -> Result<QueryResult<'_>>
+    where
+        S: AsStatement,
+        P: Into<Params>;
+
+    fn exec<S, P, T>(&mut self, stmt: S, params: P) -> Result<Vec<T>>
+    where
+        S: AsStatement,
+        P: Into<Params>,
+        T: FromRow,
+    {
+        self.exec_map(stmt, params, crate::from_row)
+    }
+
+    fn exec_first<S, P, T>(&mut self, stmt: S, params: P) -> Result<Option<T>>
+    where
+        S: AsStatement,
+        P: Into<Params>,
+        T: FromRow,
+    {
+        self.exec_iter(stmt, params)?
+            .next()
+            .map(|row| row.map(crate::from_row))
+            .transpose()
+    }
+
+    fn exec_map<S, P, F, T>(&mut self, stmt: S, params: P, mut f: F) -> Result<Vec<T>>
+    where
+        S: AsStatement,
+        P: Into<Params>,
+        F: FnMut(crate::Row) -> T,
+    {
+        self.exec_fold(stmt, params, Vec::new(), |mut acc, row| {
+            acc.push(f(row));
+            acc
+        })
+    }
+
+    fn exec_fold<S, P, T, F>(&mut self, stmt: S, params: P, init: T, mut f: F) -> Result<T>
+    where
+        S: AsStatement,
+        P: Into<Params>,
+        F: FnMut(T, crate::Row) -> T,
+    {
+        let mut result = self.exec_iter(stmt, params)?;
+        let output = result.try_fold(init, |init, row| row.map(|row| f(init, row)));
+        output
+    }
+
+    fn exec_drop<S, P>(&mut self, stmt: S, params: P) -> Result<()>
+    where
+        S: AsStatement,
+        P: Into<Params>,
+    {
+        self.exec_iter(stmt, params).map(drop)
+    }
+}


### PR DESCRIPTION
This PR:

* Changes statement to be the thin wrapper over statement id and meta;
* Changes how statement cache works;
* Extends the `Queryable` trait;
* Fixes ipv6 parsing for urls;
* Changes option builders to be "by-value";
* Extends crate-level docs.