### PR TITLE
Fix pool exhaustion on connection failure

### DIFF
--- a/src/conn/pool.rs
+++ b/src/conn/pool.rs
@@ -168,7 +168,10 @@ impl Pool {
         };
 
         if call_ping && self.check_health && !conn.ping() {
-            conn.reset()?;
+            if let Err(err) = conn.reset() {
+                self.count.fetch_sub(1, Ordering::SeqCst);
+                return Err(err);
+            }
         }
 
         Ok(PooledConn {


### PR DESCRIPTION
If the `.reset()` fails here, after we decrement `count` but before a `PooledConn` is constructed, then PooledConn's `drop` is never run and `count` is never re-incremented. After this has happened `max_threads` times,  `.get_conn()` will never succeed again.

Instead, if a `.reset()` fails, drop the `Conn` (so that its "incomplete connection" state is destroyed) and decrement `count` accordingly.