### PR TITLE
Reexport 'vendored' feature from native-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ opt-level = 3
 
 [features]
 nightly = []
+native-tls-vendored = ["native-tls/vendored"]
 
 [dev-dependencies]
 lazy_static = "1.4.0"


### PR DESCRIPTION
Allows easier cross-compilation to non-Windows, non-macOS targets by using the "vendored" feature from native-tls to compile OpenSSL from scratch instead of finding and installing OpenSSL lib files and headers.