### PR TITLE
get program_name from attr first

### DIFF
--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -544,7 +544,6 @@ impl Conn {
     }
 
     fn connect_attrs(&self) -> HashMap<String, String> {
-
         let program_name = match self.0.opts.get_connect_attrs().get("program_name") {
             Some(program_name) => program_name.clone(),
             None => {

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -544,9 +544,15 @@ impl Conn {
     }
 
     fn connect_attrs(&self) -> HashMap<String, String> {
-        let arg0 = std::env::args_os().next();
-        let arg0 = arg0.as_ref().map(|x| x.to_string_lossy());
-        let program_name = arg0.unwrap_or("".into()).to_owned();
+
+        let program_name = match self.0.opts.get_connect_attrs().get("program_name") {
+            Some(program_name) => program_name.clone(),
+            None => {
+                let arg0 = std::env::args_os().next();
+                let arg0 = arg0.as_ref().map(|x| x.to_string_lossy());
+                arg0.unwrap_or("".into()).to_owned().to_string()
+            }
+        };
 
         let mut attrs = HashMap::new();
 


### PR DESCRIPTION
in default, the program_name of attr from os.env::args[0], sometimes caller want to change it.

let opts = OptsBuilder::from_opts(&url);
let mut connect_attrs = HashMap::new();
connect_attrs.insert("program_name", "my_app");
let opts = opts.connect_attrs(connect_attrs);
let pool = Pool::new(opts)?;
