### PR TITLE
Add support for supplying root cert in .pem format

### DIFF
--- a/src/conn/opts.rs
+++ b/src/conn/opts.rs
@@ -25,7 +25,6 @@ pub struct SslOpts {
     pkcs12_path: Option<Cow<'static, Path>>,
     password: Option<Cow<'static, str>>,
     root_cert_path: Option<Cow<'static, Path>>,
-    root_cert_format: Option<CertificateFormat>,
     skip_domain_validation: bool,
     accept_invalid_certs: bool,
 }
@@ -50,33 +49,16 @@ impl SslOpts {
         self
     }
 
-    /// Sets path to a der certificate of the root that connector will trust.
+    /// Sets path to a certificate of the root that connector will trust.
     ///
-    /// If you have a certificate in PEM format, you can translate it to der
-    /// using `openssl`:
-    ///
-    /// ```text
-    /// openssl x509 -outform der -in rootca.pem -out rootca.der
-    /// ```
+    /// Supported certificate formats are .der and .pem.
+    /// If you have multiple certificates in a .pem file, only the first one will
+    /// be loaded.
     pub fn with_root_cert_path<T: Into<Cow<'static, Path>>>(
         mut self,
         root_cert_path: Option<T>,
     ) -> Self {
         self.root_cert_path = root_cert_path.map(Into::into);
-        self.root_cert_format = Some(CertificateFormat::Der);
-        self
-    }
-
-    /// Sets path to a pem certificate of the root that connector will trust.
-    ///
-    /// If you have multiple certificates in .pem file, only the first one will
-    /// be loaded.
-    pub fn with_pem_root_cert_path<T: Into<Cow<'static, Path>>>(
-        mut self,
-        root_cert_path: Option<T>,
-    ) -> Self {
-        self.root_cert_path = root_cert_path.map(Into::into);
-        self.root_cert_format = Some(CertificateFormat::Pem);
         self
     }
 
@@ -106,10 +88,6 @@ impl SslOpts {
         self.root_cert_path.as_ref().map(AsRef::as_ref)
     }
 
-    pub fn root_cert_format(&self) -> Option<CertificateFormat> {
-        self.root_cert_format.clone()
-    }
-
     pub fn skip_domain_validation(&self) -> bool {
         self.skip_domain_validation
     }
@@ -117,12 +95,6 @@ impl SslOpts {
     pub fn accept_invalid_certs(&self) -> bool {
         self.accept_invalid_certs
     }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub enum CertificateFormat {
-    Der,
-    Pem,
 }
 
 /// Options structure is quite large so we'll store it separately.

--- a/src/conn/opts.rs
+++ b/src/conn/opts.rs
@@ -68,6 +68,9 @@ impl SslOpts {
     }
 
     /// Sets path to a pem certificate of the root that connector will trust.
+    ///
+    /// If you have multiple certificates in .pem file, only the first one will
+    /// be loaded.
     pub fn with_pem_root_cert_path<T: Into<Cow<'static, Path>>>(
         mut self,
         root_cert_path: Option<T>,

--- a/src/conn/opts.rs
+++ b/src/conn/opts.rs
@@ -25,6 +25,7 @@ pub struct SslOpts {
     pkcs12_path: Option<Cow<'static, Path>>,
     password: Option<Cow<'static, str>>,
     root_cert_path: Option<Cow<'static, Path>>,
+    root_cert_format: Option<CertificateFormat>,
     skip_domain_validation: bool,
     accept_invalid_certs: bool,
 }
@@ -62,6 +63,17 @@ impl SslOpts {
         root_cert_path: Option<T>,
     ) -> Self {
         self.root_cert_path = root_cert_path.map(Into::into);
+        self.root_cert_format = Some(CertificateFormat::Der);
+        self
+    }
+
+    /// Sets path to a pem certificate of the root that connector will trust.
+    pub fn with_pem_root_cert_path<T: Into<Cow<'static, Path>>>(
+        mut self,
+        root_cert_path: Option<T>,
+    ) -> Self {
+        self.root_cert_path = root_cert_path.map(Into::into);
+        self.root_cert_format = Some(CertificateFormat::Pem);
         self
     }
 
@@ -91,6 +103,10 @@ impl SslOpts {
         self.root_cert_path.as_ref().map(AsRef::as_ref)
     }
 
+    pub fn root_cert_format(&self) -> Option<CertificateFormat> {
+        self.root_cert_format.clone()
+    }
+
     pub fn skip_domain_validation(&self) -> bool {
         self.skip_domain_validation
     }
@@ -98,6 +114,12 @@ impl SslOpts {
     pub fn accept_invalid_certs(&self) -> bool {
         self.accept_invalid_certs
     }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum CertificateFormat {
+    Der,
+    Pem,
 }
 
 /// Options structure is quite large so we'll store it separately.

--- a/src/conn/opts.rs
+++ b/src/conn/opts.rs
@@ -116,7 +116,7 @@ impl SslOpts {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum CertificateFormat {
     Der,
     Pem,

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -30,6 +30,7 @@ use crate::{
     },
     SslOpts,
 };
+use crate::conn::opts::CertificateFormat;
 
 mod tcp;
 
@@ -156,7 +157,10 @@ impl Stream {
                 let mut root_cert_der = vec![];
                 let mut root_cert_file = File::open(root_cert_path)?;
                 root_cert_file.read_to_end(&mut root_cert_der)?;
-                let root_cert = Certificate::from_der(&*root_cert_der)?;
+                let root_cert = match ssl_opts.root_cert_format().unwrap() {
+                    CertificateFormat::Der => Certificate::from_der(&*root_cert_der)?,
+                    CertificateFormat::Pem => Certificate::from_pem(&*root_cert_der)?,
+                };
                 builder.add_root_certificate(root_cert);
             }
             None => (),

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -22,6 +22,7 @@ use std::{
     time::Duration,
 };
 
+use crate::conn::opts::CertificateFormat;
 use crate::{
     error::{
         DriverError::{ConnectTimeout, CouldNotConnect},
@@ -30,7 +31,6 @@ use crate::{
     },
     SslOpts,
 };
-use crate::conn::opts::CertificateFormat;
 
 mod tcp;
 


### PR DESCRIPTION
Add support for supplying root cert in `.pem` format
Right now, there is only support for `.der` format. `.pem` is another popular format, and it would be great if `mysql` crate could support it directly for root certificate without a need to converting it to `.der`, as is currently recommended.