### PR TITLE
Add rustls support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ path = "src/lib.rs"
 opt-level = 3
 
 [features]
+default = ["rustls"]
+rustls = ["rustls-connector"]
 nightly = []
 
 [dev-dependencies]
@@ -37,13 +39,14 @@ bufstream = "~0.1"
 io-enum = "0.2.1"
 lru = "0.6.0"
 mysql_common = "0.24.1"
-native-tls = "0.2.3"
 socket2 = "0.3.12"
 percent-encoding = "2.1.0"
 serde = "1"
 serde_json = "1"
 twox-hash = "1"
 url = "2.1"
+native-tls = { version = "0.2.3", optional = true }
+rustls-connector = { version = "0.12.0", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 named_pipe = "~0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ serde_json = "1"
 twox-hash = "1"
 url = "2.1"
 native-tls = { version = "0.2.3", optional = true }
-rustls-connector = { version = "0.12.0", optional = true }
+rustls-connector = { version = "0.12.0", optional = true, features = ["dangerous-configuration"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 named_pipe = "~0.4"

--- a/src/error.rs
+++ b/src/error.rs
@@ -165,7 +165,7 @@ impl From<PacketCodecError> for Error {
 
 impl From<std::convert::Infallible> for Error {
     fn from(err: std::convert::Infallible) -> Self {
-        match err { }
+        match err {}
     }
 }
 
@@ -195,12 +195,16 @@ impl From<native_tls::HandshakeError<std::net::TcpStream>> for Error {
 
 #[cfg(feature = "rustls")]
 impl From<rustls_connector::rustls::TLSError> for Error {
-    fn from(err: rustls_connector::rustls::TLSError) -> Error { Error::TlsError(err) }
+    fn from(err: rustls_connector::rustls::TLSError) -> Error {
+        Error::TlsError(err)
+    }
 }
 
 #[cfg(feature = "rustls")]
 impl From<rustls_connector::HandshakeError<std::net::TcpStream>> for Error {
-    fn from(err: rustls_connector::HandshakeError<std::net::TcpStream>) -> Error { Error::TlsHandshakeError(err) }
+    fn from(err: rustls_connector::HandshakeError<std::net::TcpStream>) -> Error {
+        Error::TlsHandshakeError(err)
+    }
 }
 
 impl From<UrlError> for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,8 +58,14 @@ pub enum Error {
     MySqlError(MySqlError),
     DriverError(DriverError),
     UrlError(UrlError),
+    #[cfg(feature = "native-tls")]
     TlsError(native_tls::Error),
+    #[cfg(feature = "native-tls")]
     TlsHandshakeError(native_tls::HandshakeError<std::net::TcpStream>),
+    #[cfg(feature = "rustls")]
+    TlsError(rustls_connector::rustls::TLSError),
+    #[cfg(feature = "rustls")]
+    TlsHandshakeError(rustls_connector::HandshakeError<std::net::TcpStream>),
     FromValueError(Value),
     FromRowError(Row),
 }
@@ -159,7 +165,7 @@ impl From<PacketCodecError> for Error {
 
 impl From<std::convert::Infallible> for Error {
     fn from(err: std::convert::Infallible) -> Self {
-        match err {}
+        match err { }
     }
 }
 
@@ -173,16 +179,28 @@ impl From<::nix::Error> for Error {
     }
 }
 
+#[cfg(feature = "native-tls")]
 impl From<native_tls::Error> for Error {
     fn from(err: native_tls::Error) -> Error {
         Error::TlsError(err)
     }
 }
 
+#[cfg(feature = "native-tls")]
 impl From<native_tls::HandshakeError<std::net::TcpStream>> for Error {
     fn from(err: native_tls::HandshakeError<std::net::TcpStream>) -> Error {
         Error::TlsHandshakeError(err)
     }
+}
+
+#[cfg(feature = "rustls")]
+impl From<rustls_connector::rustls::TLSError> for Error {
+    fn from(err: rustls_connector::rustls::TLSError) -> Error { Error::TlsError(err) }
+}
+
+#[cfg(feature = "rustls")]
+impl From<rustls_connector::HandshakeError<std::net::TcpStream>> for Error {
+    fn from(err: rustls_connector::HandshakeError<std::net::TcpStream>) -> Error { Error::TlsHandshakeError(err) }
 }
 
 impl From<UrlError> for Error {

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -13,26 +13,17 @@ use named_pipe as np;
 #[cfg(feature = "native-tls")]
 use native_tls::{Certificate, Identity, TlsConnector, TlsStream};
 #[cfg(feature = "rustls")]
-use rustls_connector::{
-    TlsStream,
-    RustlsConnector,
-    RustlsConnectorConfig,
-};
+use rustls_connector::{RustlsConnector, RustlsConnectorConfig, TlsStream};
 
 #[cfg(unix)]
 use std::os::unix;
 use std::{
-    fmt,
-    io,
+    fmt, io,
     net::{self, SocketAddr},
     time::Duration,
 };
 #[cfg(feature = "native-tls")]
-use std::{
-    io::Read as _,
-    fs::File
-};
-
+use std::{fs::File, io::Read as _};
 
 use crate::{
     error::{


### PR DESCRIPTION
Adds the `rustls` feature, which will use `rustls` over `native-tls`, and is used by default.

`native-tls` is still available as a feature.