### PR TITLE
Bump nix version to 0.23.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,5 +53,4 @@ named_pipe = "~0.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-nix = "0.21.0"
-
+nix = "0.23.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -165,11 +165,8 @@ impl From<std::convert::Infallible> for Error {
 
 #[cfg(unix)]
 impl From<::nix::Error> for Error {
-    fn from(x: ::nix::Error) -> Error {
-        match x {
-            ::nix::Error::Sys(errno) => Error::from(io::Error::from_raw_os_error(errno as i32)),
-            _ => Error::from(io::Error::new(io::ErrorKind::Other, x)),
-        }
+    fn from(errno: ::nix::Error) -> Error {
+        Error::from(io::Error::from_raw_os_error(errno as i32))
     }
 }
 


### PR DESCRIPTION
For me this is primarily to patch [RUSTSEC-2021-0119](https://rustsec.org/advisories/RUSTSEC-2021-0119)