### PR TITLE
Expose as fd + opts can set tcp_user_timeout

### DIFF
--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -386,6 +386,8 @@ impl Conn {
         let read_timeout = opts.get_read_timeout().cloned();
         let write_timeout = opts.get_write_timeout().cloned();
         let tcp_keepalive_time = opts.get_tcp_keepalive_time_ms();
+        #[cfg(target_os = "linux")]
+        let tcp_user_timeout = opts.get_tcp_user_timeout_ms();
         let tcp_nodelay = opts.get_tcp_nodelay();
         let tcp_connect_timeout = opts.get_tcp_connect_timeout();
         let bind_address = opts.bind_address().cloned();
@@ -404,6 +406,8 @@ impl Conn {
                 read_timeout,
                 write_timeout,
                 tcp_keepalive_time,
+                #[cfg(target_os = "linux")]
+                tcp_user_timeout,
                 tcp_nodelay,
                 tcp_connect_timeout,
                 bind_address,

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -40,6 +40,9 @@ use std::{
     sync::Arc,
 };
 
+#[cfg(unix)]
+use std::os::unix::io::{AsRawFd, RawFd};
+
 use crate::{
     buffer_pool::{get_buffer, Buffer},
     conn::{
@@ -1111,6 +1114,13 @@ impl Conn {
     pub fn get_binlog_stream(mut self, request: BinlogRequest<'_>) -> Result<BinlogStream> {
         self.request_binlog(request)?;
         Ok(BinlogStream::new(self))
+    }
+}
+
+#[cfg(unix)]
+impl AsRawFd for Conn {
+    fn as_raw_fd(&self) -> RawFd {
+        self.stream_ref().get_ref().as_raw_fd()
     }
 }
 

--- a/src/conn/opts/mod.rs
+++ b/src/conn/opts/mod.rs
@@ -135,6 +135,8 @@ pub(crate) struct InnerOpts {
     tcp_keepalive_time: Option<u32>,
 
     /// TCP_USER_TIMEOUT time for mysql connection.
+    ///
+    /// Can be defined using `tcp_user_timeout_ms` connection url parameter.
     #[cfg(target_os = "linux")]
     tcp_user_timeout: Option<u32>,
 
@@ -488,7 +490,7 @@ impl OptsBuilder {
     /// - db_name = Database name (defaults to `None`).
     /// - prefer_socket = Prefer socket connection (defaults to `true`)
     /// - tcp_keepalive_time_ms = TCP keep alive time for mysql connection (defaults to `None`)
-    /// - tcp_user_timeout = TCP_USER_TIMEOUT time for mysql connection (defaults to `None`)
+    /// - tcp_user_timeout_ms = TCP_USER_TIMEOUT time for mysql connection (defaults to `None`)
     /// - compress = Compression level(defaults to `None`)
     /// - tcp_connect_timeout_ms = Tcp connect timeout (defaults to `None`)
     /// - stmt_cache_size = Number of prepared statements cached on the client side (per connection)
@@ -540,8 +542,7 @@ impl OptsBuilder {
                     }
                 }
                 #[cfg(target_os = "linux")]
-                "tcp_user_timeout" => {
-                    //if cannot parse, default to none
+                "tcp_user_timeout_ms" => {
                     self.opts.0.tcp_user_timeout = match value.parse::<u32>() {
                         Ok(val) => Some(val),
                         _ => {
@@ -661,12 +662,12 @@ impl OptsBuilder {
     }
 
     /// TCP_USER_TIMEOUT for mysql connection (defaults to `None`). Available as
-    /// `tcp_user_timeout` url parameter.
+    /// `tcp_user_timeout_ms` url parameter.
     ///
-    /// Can be defined using `tcp_user_timeout` connection url parameter.
+    /// Can be defined using `tcp_user_timeout_ms` connection url parameter.
     #[cfg(target_os = "linux")]
-    pub fn tcp_user_timeout(mut self, tcp_user_timeout: Option<u32>) -> Self {
-        self.opts.0.tcp_user_timeout = tcp_user_timeout;
+    pub fn tcp_user_timeout_ms(mut self, tcp_user_timeout_ms: Option<u32>) -> Self {
+        self.opts.0.tcp_user_timeout = tcp_user_timeout_ms;
         self
     }
 
@@ -956,7 +957,7 @@ mod test {
     #[test]
     fn should_convert_url_into_opts() {
         #[cfg(target_os = "linux")]
-        let tcp_user_timeout = "&tcp_user_timeout=6000";
+        let tcp_user_timeout = "&tcp_user_timeout_ms=6000";
         #[cfg(not(target_os = "linux"))]
         let tcp_user_timeout = "";
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -96,6 +96,7 @@ impl Stream {
         read_timeout: Option<Duration>,
         write_timeout: Option<Duration>,
         tcp_keepalive_time: Option<u32>,
+        #[cfg(target_os = "linux")] tcp_user_timeout: Option<u32>,
         nodelay: bool,
         tcp_connect_timeout: Option<Duration>,
         bind_address: Option<SocketAddr>,
@@ -108,6 +109,8 @@ impl Stream {
             .keepalive_time_ms(tcp_keepalive_time)
             .nodelay(nodelay)
             .bind_address(bind_address);
+        #[cfg(target_os = "linux")]
+        builder.user_timeout(tcp_user_timeout);
         builder
             .connect()
             .map(|stream| Stream::TcpStream(TcpStream::Insecure(BufStream::new(stream))))


### PR DESCRIPTION
TCP timeouts are hard.

I have observed that in one specific scenario, namely when target endpoint goes down in aws land, application connecting to db hangs for around 15 minutes, even with setting the connect_timeout, I don't want to set read_timeout as that may have undesirable effect on long executing queries

Now, my knowledge in tcp is very accidental, but the `TCP_USER_TIMEOUT` seems to achieve the desired behavior.

I have added 2 commits:
1) impl  as_raw_fd(), this way I could have modified the user_timeout without having to hack the library
2) Since I am here, add support in Opts to handle `tcp_user_timeout` via ops.

I have not tested whether this builds on non linux platform. 