### PR TITLE
keepalive: allow setting of probe interval & probe count

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ structure in the create API docs):
 *   `prefer_socket: true | false` - defines the value of the same field in the `Opts` structure;
 *   `tcp_keepalive_time_ms: u32` - defines the value (in milliseconds)
     of the `tcp_keepalive_time` field in the `Opts` structure;
+*   `tcp_keepalive_probe_interval_secs: u32` - defines the value
+    of the `tcp_keepalive_probe_interval_secs` field in the `Opts` structure;
+*   `tcp_keepalive_probe_count: u32` - defines the value
+    of the `tcp_keepalive_probe_count` field in the `Opts` structure;
 *   `tcp_connect_timeout_ms: u64` - defines the value (in milliseconds)
     of the `tcp_connect_timeout` field in the `Opts` structure;
 *   `tcp_user_timeout_ms` - defines the value (in milliseconds)

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -391,6 +391,8 @@ impl Conn {
         let read_timeout = opts.get_read_timeout().cloned();
         let write_timeout = opts.get_write_timeout().cloned();
         let tcp_keepalive_time = opts.get_tcp_keepalive_time_ms();
+        #[cfg(any(target_os = "linux", target_os = "macos",))]
+        let tcp_keepalive_probe_count = opts.get_tcp_keepalive_probe_count();
         #[cfg(target_os = "linux")]
         let tcp_user_timeout = opts.get_tcp_user_timeout_ms();
         let tcp_nodelay = opts.get_tcp_nodelay();
@@ -411,6 +413,8 @@ impl Conn {
                 read_timeout,
                 write_timeout,
                 tcp_keepalive_time,
+                #[cfg(any(target_os = "linux", target_os = "macos",))]
+                tcp_keepalive_probe_count,
                 #[cfg(target_os = "linux")]
                 tcp_user_timeout,
                 tcp_nodelay,

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -392,6 +392,8 @@ impl Conn {
         let write_timeout = opts.get_write_timeout().cloned();
         let tcp_keepalive_time = opts.get_tcp_keepalive_time_ms();
         #[cfg(any(target_os = "linux", target_os = "macos",))]
+        let tcp_keepalive_probe_interval_secs = opts.get_tcp_keepalive_probe_interval_secs();
+        #[cfg(any(target_os = "linux", target_os = "macos",))]
         let tcp_keepalive_probe_count = opts.get_tcp_keepalive_probe_count();
         #[cfg(target_os = "linux")]
         let tcp_user_timeout = opts.get_tcp_user_timeout_ms();
@@ -413,6 +415,8 @@ impl Conn {
                 read_timeout,
                 write_timeout,
                 tcp_keepalive_time,
+                #[cfg(any(target_os = "linux", target_os = "macos",))]
+                tcp_keepalive_probe_interval_secs,
                 #[cfg(any(target_os = "linux", target_os = "macos",))]
                 tcp_keepalive_probe_count,
                 #[cfg(target_os = "linux")]

--- a/src/conn/opts/mod.rs
+++ b/src/conn/opts/mod.rs
@@ -134,6 +134,12 @@ pub(crate) struct InnerOpts {
     /// Can be defined using `tcp_keepalive_time_ms` connection url parameter.
     tcp_keepalive_time: Option<u32>,
 
+    /// TCP keep alive probe count for mysql connection.
+    ///
+    /// Can be defined using `tcp_keepalive_probe_count` connection url parameter.
+    #[cfg(any(target_os = "linux", target_os = "macos",))]
+    tcp_keepalive_probe_count: Option<u32>,
+
     /// TCP_USER_TIMEOUT time for mysql connection.
     ///
     /// Can be defined using `tcp_user_timeout_ms` connection url parameter.
@@ -222,6 +228,8 @@ impl Default for InnerOpts {
             init: vec![],
             ssl_opts: None,
             tcp_keepalive_time: None,
+            #[cfg(any(target_os = "linux", target_os = "macos",))]
+            tcp_keepalive_probe_count: None,
             #[cfg(target_os = "linux")]
             tcp_user_timeout: None,
             tcp_nodelay: true,
@@ -326,6 +334,12 @@ impl Opts {
     /// TCP keep alive time for mysql connection.
     pub fn get_tcp_keepalive_time_ms(&self) -> Option<u32> {
         self.0.tcp_keepalive_time
+    }
+
+    /// TCP keep alive probe count for mysql connection.
+    #[cfg(any(target_os = "linux", target_os = "macos",))]
+    pub fn get_tcp_keepalive_probe_count(&self) -> Option<u32> {
+        self.0.tcp_keepalive_probe_count
     }
 
     /// TCP_USER_TIMEOUT time for mysql connection.
@@ -490,6 +504,7 @@ impl OptsBuilder {
     /// - db_name = Database name (defaults to `None`).
     /// - prefer_socket = Prefer socket connection (defaults to `true`)
     /// - tcp_keepalive_time_ms = TCP keep alive time for mysql connection (defaults to `None`)
+    /// - tcp_keepalive_probe_count = TCP keep alive probe count for mysql connection (defaults to `None`)
     /// - tcp_user_timeout_ms = TCP_USER_TIMEOUT time for mysql connection (defaults to `None`)
     /// - compress = Compression level(defaults to `None`)
     /// - tcp_connect_timeout_ms = Tcp connect timeout (defaults to `None`)
@@ -535,6 +550,16 @@ impl OptsBuilder {
                 "tcp_keepalive_time_ms" => {
                     //if cannot parse, default to none
                     self.opts.0.tcp_keepalive_time = match value.parse::<u32>() {
+                        Ok(val) => Some(val),
+                        _ => {
+                            return Err(UrlError::InvalidValue(key.to_string(), value.to_string()))
+                        }
+                    }
+                }
+                #[cfg(any(target_os = "linux", target_os = "macos",))]
+                "tcp_keepalive_probe_count" => {
+                    //if cannot parse, default to none
+                    self.opts.0.tcp_keepalive_probe_count = match value.parse::<u32>() {
                         Ok(val) => Some(val),
                         _ => {
                             return Err(UrlError::InvalidValue(key.to_string(), value.to_string()))
@@ -658,6 +683,16 @@ impl OptsBuilder {
     /// Can be defined using `tcp_keepalive_time_ms` connection url parameter.
     pub fn tcp_keepalive_time_ms(mut self, tcp_keepalive_time_ms: Option<u32>) -> Self {
         self.opts.0.tcp_keepalive_time = tcp_keepalive_time_ms;
+        self
+    }
+
+    /// TCP keep alive probe count for mysql connection (defaults to `None`). Available as
+    /// `tcp_keepalive_probe_count` url parameter.
+    ///
+    /// Can be defined using `tcp_keepalive_probe_count` connection url parameter.
+    #[cfg(any(target_os = "linux", target_os = "macos",))]
+    pub fn tcp_keepalive_probe_count(mut self, tcp_keepalive_probe_count: Option<u32>) -> Self {
+        self.opts.0.tcp_keepalive_probe_count = tcp_keepalive_probe_count;
         self
     }
 
@@ -956,13 +991,19 @@ mod test {
 
     #[test]
     fn should_convert_url_into_opts() {
+        #[cfg(any(target_os = "linux", target_os = "macos",))]
+        let tcp_keepalive_probe_count = "&tcp_keepalive_probe_count=5";
+        #[cfg(not(any(target_os = "linux", target_os = "macos",)))]
+        let tcp_keepalive_probe_count = "";
+
         #[cfg(target_os = "linux")]
         let tcp_user_timeout = "&tcp_user_timeout_ms=6000";
         #[cfg(not(target_os = "linux"))]
         let tcp_user_timeout = "";
 
         let opts = format!(
-            "mysql://us%20r:p%20w@localhost:3308/db%2dname?prefer_socket=false&tcp_keepalive_time_ms=5000{}&socket=%2Ftmp%2Fmysql.sock&compress=8",
+            "mysql://us%20r:p%20w@localhost:3308/db%2dname?prefer_socket=false&tcp_keepalive_time_ms=5000{}{}&socket=%2Ftmp%2Fmysql.sock&compress=8",
+            tcp_keepalive_probe_count,
             tcp_user_timeout,
         );
         assert_eq!(
@@ -974,6 +1015,8 @@ mod test {
                 db_name: Some("db-name".to_string()),
                 prefer_socket: false,
                 tcp_keepalive_time: Some(5000),
+                #[cfg(any(target_os = "linux", target_os = "macos",))]
+                tcp_keepalive_probe_count: Some(5),
                 #[cfg(target_os = "linux")]
                 tcp_user_timeout: Some(6000),
                 socket: Some("/tmp/mysql.sock".into()),
@@ -1020,7 +1063,7 @@ mod test {
             };
         );
 
-        let cnf_map = map! {
+        let mut cnf_map = map! {
             "user".to_string() => "test".to_string(),
             "password".to_string() => "password".to_string(),
             "host".to_string() => "127.0.0.1".to_string(),
@@ -1032,6 +1075,8 @@ mod test {
             "tcp_connect_timeout_ms".to_string() => "1000".to_string(),
             "stmt_cache_size".to_string() => "33".to_string()
         };
+        #[cfg(any(target_os = "linux", target_os = "macos",))]
+        cnf_map.insert("tcp_keepalive_probe_count".to_string(), "5".to_string());
 
         let parsed_opts = OptsBuilder::new().from_hash_map(&cnf_map).unwrap();
 
@@ -1042,6 +1087,8 @@ mod test {
         assert_eq!(parsed_opts.opts.get_db_name(), Some("test_db"));
         assert_eq!(parsed_opts.opts.get_prefer_socket(), false);
         assert_eq!(parsed_opts.opts.get_tcp_keepalive_time_ms(), Some(5000));
+        #[cfg(any(target_os = "linux", target_os = "macos",))]
+        assert_eq!(parsed_opts.opts.get_tcp_keepalive_probe_count(), Some(5));
         assert_eq!(
             parsed_opts.opts.get_compress(),
             Some(crate::Compression::best())

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -96,6 +96,8 @@ impl Stream {
         read_timeout: Option<Duration>,
         write_timeout: Option<Duration>,
         tcp_keepalive_time: Option<u32>,
+        #[cfg(any(target_os = "linux", target_os = "macos",))]
+        tcp_keepalive_probe_interval_secs: Option<u32>,
         #[cfg(any(target_os = "linux", target_os = "macos",))] tcp_keepalive_probe_count: Option<
             u32,
         >,
@@ -112,6 +114,8 @@ impl Stream {
             .keepalive_time_ms(tcp_keepalive_time)
             .nodelay(nodelay)
             .bind_address(bind_address);
+        #[cfg(any(target_os = "linux", target_os = "macos",))]
+        builder.keepalive_probe_interval_secs(tcp_keepalive_probe_interval_secs);
         #[cfg(any(target_os = "linux", target_os = "macos",))]
         builder.keepalive_probe_count(tcp_keepalive_probe_count);
         #[cfg(target_os = "linux")]

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -96,6 +96,9 @@ impl Stream {
         read_timeout: Option<Duration>,
         write_timeout: Option<Duration>,
         tcp_keepalive_time: Option<u32>,
+        #[cfg(any(target_os = "linux", target_os = "macos",))] tcp_keepalive_probe_count: Option<
+            u32,
+        >,
         #[cfg(target_os = "linux")] tcp_user_timeout: Option<u32>,
         nodelay: bool,
         tcp_connect_timeout: Option<Duration>,
@@ -109,6 +112,8 @@ impl Stream {
             .keepalive_time_ms(tcp_keepalive_time)
             .nodelay(nodelay)
             .bind_address(bind_address);
+        #[cfg(any(target_os = "linux", target_os = "macos",))]
+        builder.keepalive_probe_count(tcp_keepalive_probe_count);
         #[cfg(target_os = "linux")]
         builder.user_timeout(tcp_user_timeout);
         builder

--- a/src/io/tcp.rs
+++ b/src/io/tcp.rs
@@ -21,6 +21,8 @@ pub struct MyTcpBuilder<T> {
     read_timeout: Option<Duration>,
     write_timeout: Option<Duration>,
     keepalive_time_ms: Option<u32>,
+    #[cfg(any(target_os = "linux", target_os = "macos",))]
+    keepalive_probe_count: Option<u32>,
     #[cfg(target_os = "linux")]
     user_timeout: Option<u32>,
     nodelay: bool,
@@ -29,6 +31,12 @@ pub struct MyTcpBuilder<T> {
 impl<T: ToSocketAddrs> MyTcpBuilder<T> {
     pub fn keepalive_time_ms(&mut self, keepalive_time_ms: Option<u32>) -> &mut Self {
         self.keepalive_time_ms = keepalive_time_ms;
+        self
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos",))]
+    pub fn keepalive_probe_count(&mut self, keepalive_probe_count: Option<u32>) -> &mut Self {
+        self.keepalive_probe_count = keepalive_probe_count;
         self
     }
 
@@ -74,6 +82,8 @@ impl<T: ToSocketAddrs> MyTcpBuilder<T> {
             read_timeout: None,
             write_timeout: None,
             keepalive_time_ms: None,
+            #[cfg(any(target_os = "linux", target_os = "macos",))]
+            keepalive_probe_count: None,
             #[cfg(target_os = "linux")]
             user_timeout: None,
             nodelay: true,
@@ -88,6 +98,8 @@ impl<T: ToSocketAddrs> MyTcpBuilder<T> {
             read_timeout,
             write_timeout,
             keepalive_time_ms,
+            #[cfg(any(target_os = "linux", target_os = "macos",))]
+            keepalive_probe_count,
             #[cfg(target_os = "linux")]
             user_timeout,
             nodelay,
@@ -157,6 +169,23 @@ impl<T: ToSocketAddrs> MyTcpBuilder<T> {
             let conf =
                 socket2::TcpKeepalive::new().with_time(Duration::from_millis(duration as u64));
             socket.set_tcp_keepalive(&conf)?;
+        }
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        if let Some(keepalive_probe_count) = keepalive_probe_count {
+            use std::os::unix::io::AsRawFd;
+            let fd = socket.as_raw_fd();
+            unsafe {
+                if libc::setsockopt(
+                    fd,
+                    libc::IPPROTO_TCP,
+                    libc::TCP_KEEPCNT,
+                    &keepalive_probe_count as *const _ as *const libc::c_void,
+                    std::mem::size_of_val(&keepalive_probe_count) as libc::socklen_t,
+                ) != 0
+                {
+                    return Err(io::Error::last_os_error());
+                }
+            }
         }
         #[cfg(target_os = "linux")]
         if let Some(timeout) = user_timeout {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,8 @@
 //! *   `prefer_socket: true | false` - defines the value of the same field in the `Opts` structure;
 //! *   `tcp_keepalive_time_ms: u32` - defines the value (in milliseconds)
 //!     of the `tcp_keepalive_time` field in the `Opts` structure;
+//! *   `tcp_keepalive_probe_interval_secs: u32` - defines the value
+//!     of the `tcp_keepalive_probe_interval_secs` field in the `Opts` structure;
 //! *   `tcp_keepalive_probe_count: u32` - defines the value
 //!     of the `tcp_keepalive_probe_count` field in the `Opts` structure;
 //! *   `tcp_connect_timeout_ms: u64` - defines the value (in milliseconds)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,8 @@
 //! *   `prefer_socket: true | false` - defines the value of the same field in the `Opts` structure;
 //! *   `tcp_keepalive_time_ms: u32` - defines the value (in milliseconds)
 //!     of the `tcp_keepalive_time` field in the `Opts` structure;
+//! *   `tcp_keepalive_probe_count: u32` - defines the value
+//!     of the `tcp_keepalive_probe_count` field in the `Opts` structure;
 //! *   `tcp_connect_timeout_ms: u64` - defines the value (in milliseconds)
 //!     of the `tcp_connect_timeout` field in the `Opts` structure;
 //! *   `tcp_user_timeout_ms` - defines the value (in milliseconds)


### PR DESCRIPTION
Currently the library only allows setting of the keepalive idle time
I think that is driven by the fact the socket2 only exposes this code easily - that is without the `all` feature flag.

Well, it's kinda odd that they do only that, so I have raised a PR there: https://github.com/rust-lang/socket2/pull/294 but I am not sure if that will be merged and when.

In the meantime we can easily add the support of that into this crate, just by using more `roo` API. 