### PR TITLE
Upgrade nix to 0.24.1, limit features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,4 +94,3 @@ named_pipe = "~0.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-nix = { version = "0.24.1", default-features = false, features = [] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,4 +94,4 @@ named_pipe = "~0.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-nix = "0.23.0"
+nix = { version = "0.24.1", default-features = false, features = [] }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -157,13 +157,6 @@ impl From<std::convert::Infallible> for Error {
     }
 }
 
-#[cfg(unix)]
-impl From<::nix::Error> for Error {
-    fn from(errno: ::nix::Error) -> Error {
-        Error::from(io::Error::from_raw_os_error(errno as i32))
-    }
-}
-
 impl From<UrlError> for Error {
     fn from(err: UrlError) -> Error {
         Error::UrlError(err)


### PR DESCRIPTION
This decreases build times slightly.

nix is only used to provide a [`From` implementation](https://github.com/blackbeam/rust-mysql-simple/blob/3c4d4eeb1222c863bac82d98dc5700a9914ccb68/src/error/mod.rs#L161-L165), we don't actually need the full crate.