### PR TITLE
Use user-friendly Result alias

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -342,7 +342,7 @@ impl From<ParseError> for UrlError {
     }
 }
 
-pub type Result<T> = result::Result<T, Error>;
+pub type Result<T, E = Error> = result::Result<T, E>;
 
 /// Server error codes (u16)
 #[allow(non_camel_case_types)]


### PR DESCRIPTION
The current `Result` alias [can cause confusing errors for users](https://users.rust-lang.org/t/conflicting-messages-when-i-try-to-provide-an-implementation-for-mysql-fromrow/90474/1) who use glob imports. This tweak makes it transparently support two-arg usage.
