### PR TITLE
Bump mysql_common to 0.30.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,9 @@ default = [
     "flate2/zlib",
 
     # set of enabled-by-default mysql_common features
-    "mysql_common/bigdecimal03",
+    "mysql_common/bigdecimal",
     "mysql_common/rust_decimal",
-    "mysql_common/time03",
-    "mysql_common/uuid",
+    "mysql_common/time",
     "mysql_common/frunk",
 
     # use global buffer pool by default
@@ -44,10 +43,9 @@ default = [
 default-rustls = [
     "rustls-tls",
     "flate2/zlib",
-    "mysql_common/bigdecimal03",
+    "mysql_common/bigdecimal",
     "mysql_common/rust_decimal",
-    "mysql_common/time03",
-    "mysql_common/uuid",
+    "mysql_common/time",
     "mysql_common/frunk",
     "buffer-pool",
 ]
@@ -70,7 +68,7 @@ crossbeam = "0.8.1"
 io-enum = "1.0.0"
 flate2 = { version = "1.0", default-features = false }
 lru = "0.8.1"
-mysql_common = { version = "0.29.2", default-features = false }
+mysql_common = { version = "0.30.3", default-features = false }
 socket2 = "0.4"
 once_cell = "1.7.2"
 pem = "1.0.1"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,11 +45,11 @@ jobs:
           SSL=false COMPRESS=true cargo test
           SSL=true COMPRESS=true cargo test
 
-          SSL=true COMPRESS=false cargo test --no-default-features --features rustls-tls,flate2/zlib,mysql_common/time03,mysql_common/frunk
-          SSL=true COMPRESS=true cargo test --no-default-features --features rustls-tls,flate2/zlib,mysql_common/time03,mysql_common/frunk
+          SSL=true COMPRESS=false cargo test --no-default-features --features rustls-tls,flate2/zlib,mysql_common/time,mysql_common/frunk
+          SSL=true COMPRESS=true cargo test --no-default-features --features rustls-tls,flate2/zlib,mysql_common/time,mysql_common/frunk
 
-          SSL=false COMPRESS=true cargo test --no-default-features --features flate2/zlib,mysql_common/time03,mysql_common/frunk
-          SSL=false COMPRESS=false cargo test --no-default-features --features flate2/zlib,mysql_common/time03,mysql_common/frunk
+          SSL=false COMPRESS=true cargo test --no-default-features --features flate2/zlib,mysql_common/time,mysql_common/frunk
+          SSL=false COMPRESS=false cargo test --no-default-features --features flate2/zlib,mysql_common/time,mysql_common/frunk
         env:
           RUST_BACKTRACE: 1
           DATABASE_URL: mysql://root:root@localhost:3306/mysql
@@ -91,11 +91,11 @@ jobs:
           SSL=false COMPRESS=true cargo test
           SSL=true COMPRESS=true cargo test
 
-          SSL=true COMPRESS=false cargo test --no-default-features --features rustls-tls,flate2/zlib,mysql_common/time03,mysql_common/frunk
-          SSL=true COMPRESS=true cargo test --no-default-features --features rustls-tls,flate2/zlib,mysql_common/time03,mysql_common/frunk
+          SSL=true COMPRESS=false cargo test --no-default-features --features rustls-tls,flate2/zlib,mysql_common/time,mysql_common/frunk
+          SSL=true COMPRESS=true cargo test --no-default-features --features rustls-tls,flate2/zlib,mysql_common/time,mysql_common/frunk
 
-          SSL=false COMPRESS=true cargo test --no-default-features --features flate2/zlib,mysql_common/time03,mysql_common/frunk
-          SSL=false COMPRESS=false cargo test --no-default-features --features flate2/zlib,mysql_common/time03,mysql_common/frunk
+          SSL=false COMPRESS=true cargo test --no-default-features --features flate2/zlib,mysql_common/time,mysql_common/frunk
+          SSL=false COMPRESS=false cargo test --no-default-features --features flate2/zlib,mysql_common/time,mysql_common/frunk
         env:
           RUST_BACKTRACE: 1
           DATABASE_URL: mysql://root@localhost/mysql
@@ -142,11 +142,11 @@ jobs:
           SSL=false COMPRESS=true cargo test
           SSL=true COMPRESS=true cargo test
 
-          SSL=true COMPRESS=false cargo test --no-default-features --features rustls-tls,flate2/zlib,mysql_common/time03,mysql_common/frunk
-          SSL=true COMPRESS=true cargo test --no-default-features --features rustls-tls,flate2/zlib,mysql_common/time03,mysql_common/frunk
+          SSL=true COMPRESS=false cargo test --no-default-features --features rustls-tls,flate2/zlib,mysql_common/time,mysql_common/frunk
+          SSL=true COMPRESS=true cargo test --no-default-features --features rustls-tls,flate2/zlib,mysql_common/time,mysql_common/frunk
 
-          SSL=false COMPRESS=true cargo test --no-default-features --features flate2/zlib,mysql_common/time03,mysql_common/frunk
-          SSL=false COMPRESS=false cargo test --no-default-features --features flate2/zlib,mysql_common/time03,mysql_common/frunk
+          SSL=false COMPRESS=true cargo test --no-default-features --features flate2/zlib,mysql_common/time,mysql_common/frunk
+          SSL=false COMPRESS=false cargo test --no-default-features --features flate2/zlib,mysql_common/time,mysql_common/frunk
         env:
           RUST_BACKTRACE: 1
           DATABASE_URL: mysql://root:password@localhost/mysql
@@ -214,11 +214,11 @@ jobs:
           docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=$SSL cargo test"
           docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=$SSL COMPRESS=true cargo test"
 
-          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true COMPRESS=false cargo test --no-default-features --features rustls-tls,flate2/zlib,mysql_common/time03,mysql_common/frunk"
-          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true COMPRESS=true cargo test --no-default-features --features rustls-tls,flate2/zlib,mysql_common/time03,mysql_common/frunk"
+          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true COMPRESS=false cargo test --no-default-features --features rustls-tls,flate2/zlib,mysql_common/time,mysql_common/frunk"
+          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true COMPRESS=true cargo test --no-default-features --features rustls-tls,flate2/zlib,mysql_common/time,mysql_common/frunk"
 
-          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=false COMPRESS=true cargo test --no-default-features --features flate2/zlib,mysql_common/time03,mysql_common/frunk"
-          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=false COMPRESS=false cargo test --no-default-features --features flate2/zlib,mysql_common/time03,mysql_common/frunk"
+          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=false COMPRESS=true cargo test --no-default-features --features flate2/zlib,mysql_common/time,mysql_common/frunk"
+          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=false COMPRESS=false cargo test --no-default-features --features flate2/zlib,mysql_common/time,mysql_common/frunk"
         env:
           RUST_BACKTRACE: 1
           DATABASE_URL: mysql://root:password@localhost/mysql
@@ -286,11 +286,11 @@ jobs:
           docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true cargo test"
           docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true COMPRESS=true cargo test"
 
-          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true COMPRESS=false cargo test --no-default-features --features rustls-tls,flate2/zlib,mysql_common/time03,mysql_common/frunk"
-          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true COMPRESS=true cargo test --no-default-features --features rustls-tls,flate2/zlib,mysql_common/time03,mysql_common/frunk"
+          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true COMPRESS=false cargo test --no-default-features --features rustls-tls,flate2/zlib,mysql_common/time,mysql_common/frunk"
+          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true COMPRESS=true cargo test --no-default-features --features rustls-tls,flate2/zlib,mysql_common/time,mysql_common/frunk"
 
-          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=false COMPRESS=true cargo test --no-default-features --features flate2/zlib,mysql_common/time03,mysql_common/frunk"
-          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=false COMPRESS=false cargo test --no-default-features --features flate2/zlib,mysql_common/time03,mysql_common/frunk"
+          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=false COMPRESS=true cargo test --no-default-features --features flate2/zlib,mysql_common/time,mysql_common/frunk"
+          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=false COMPRESS=false cargo test --no-default-features --features flate2/zlib,mysql_common/time,mysql_common/frunk"
         env:
           RUST_BACKTRACE: 1
           DATABASE_URL: mysql://root:password@localhost/mysql

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -938,7 +938,7 @@ pub mod prelude {
     #[doc(inline)]
     pub use crate::myc::row::ColumnIndex;
     #[doc(inline)]
-    pub use crate::myc::value::convert::{ConvIr, FromValue, ToValue};
+    pub use crate::myc::value::convert::{FromValue, ToValue};
 
     /// Trait for protocol markers [`crate::Binary`] and [`crate::Text`].
     pub trait Protocol: crate::conn::query_result::Protocol {}


### PR DESCRIPTION
Notable changes:

* There's now an AuthPlugin::MysqlClearPassword variant that can be matched on rather than matching on the plugin name in AuthPlugin::Other
* Some ownership issues with `gen_data` requires calling `into_owned()` on the result
* `ConvIr` no longer exists
* Changes to feature flag names