### PR TITLE
switch inherent `as_{ref,mut}` methods to std traits where possible

### DIFF
--- a/src/conn/pool/mod.rs
+++ b/src/conn/pool/mod.rs
@@ -266,18 +266,6 @@ impl PooledConn {
         self.conn.take().unwrap().get_binlog_stream(request)
     }
 
-    /// Gives mutable reference to the wrapped
-    /// [`Conn`](struct.Conn.html).
-    pub fn as_mut(&mut self) -> &mut Conn {
-        self.conn.as_mut().unwrap()
-    }
-
-    /// Gives reference to the wrapped
-    /// [`Conn`](struct.Conn.html).
-    pub fn as_ref(&self) -> &Conn {
-        self.conn.as_ref().unwrap()
-    }
-
     /// Unwraps wrapped [`Conn`](struct.Conn.html).
     pub fn unwrap(mut self) -> Conn {
         self.conn.take().unwrap()
@@ -320,6 +308,13 @@ impl AsRef<Conn> for PooledConn {
     /// Gives reference to the wrapped [`Conn`].
     fn as_ref(&self) -> &Conn {
         self.conn.as_ref().unwrap()
+    }
+}
+
+impl AsMut<Conn> for PooledConn {
+    /// Gives mutable reference to the wrapped [`Conn`].
+    fn as_mut(&mut self) -> &mut Conn {
+        self.conn.as_mut().unwrap()
     }
 }
 

--- a/src/conn/pool/mod.rs
+++ b/src/conn/pool/mod.rs
@@ -316,6 +316,13 @@ impl PooledConn {
     }
 }
 
+impl AsRef<Conn> for PooledConn {
+    /// Gives reference to the wrapped [`Conn`].
+    fn as_ref(&self) -> &Conn {
+        self.conn.as_ref().unwrap()
+    }
+}
+
 impl Queryable for PooledConn {
     fn query_iter<T: AsRef<str>>(&mut self, query: T) -> Result<QueryResult<'_, '_, '_, Text>> {
         self.conn.as_mut().unwrap().query_iter(query)

--- a/src/conn/query_result.rs
+++ b/src/conn/query_result.rs
@@ -391,8 +391,10 @@ impl<'a> SetColumns<'a> {
             .as_ref()
             .and_then(|cols| cols.iter().position(|col| col.name_ref() == name))
     }
+}
 
-    pub fn as_ref(&self) -> &[Column] {
+impl AsRef<[Column]> for SetColumns<'_> {
+    fn as_ref(&self) -> &[Column] {
         self.inner
             .as_ref()
             .map(|cols| &(*cols)[..])


### PR DESCRIPTION
suggested by clippy, seems reasonable to me

this change is non-breaking