### PR TITLE
Fine-tune the Ordering for count

### DIFF
--- a/src/conn/pool/inner.rs
+++ b/src/conn/pool/inner.rs
@@ -68,17 +68,17 @@ pub struct Inner {
 
 impl Inner {
     pub fn increase(&self) {
-        let prev = self.count.fetch_add(1, Ordering::SeqCst);
+        let prev = self.count.fetch_add(1, Ordering::Relaxed);
         debug_assert!(prev < self.max_constraint());
     }
 
     pub fn decrease(&self) {
-        let prev = self.count.fetch_sub(1, Ordering::SeqCst);
+        let prev = self.count.fetch_sub(1, Ordering::Relaxed);
         debug_assert!(prev > 0);
     }
 
     pub fn count(&self) -> usize {
-        let value = self.count.load(Ordering::SeqCst);
+        let value = self.count.load(Ordering::Relaxed);
         debug_assert!(value <= self.max_constraint());
         value
     }


### PR DESCRIPTION
https://github.com/blackbeam/rust-mysql-simple/blob/e0fbfe41f23e9004a0bd7f997c388591ce07b40b/src/conn/pool/inner.rs#L70-L84

Here `count` is employed solely for counting purposes, rather than for synchronizing access to other shared variables. While Ordering::SeqCst guarantees program correctness, it can also impact performance. Therefore, using Ordering::Relaxed is sufficient to maintain the program's correctness without adversely affecting its efficiency.