### PR TITLE
Upgrade to twox-hash 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ pem = "3"
 percent-encoding = "2.1.0"
 serde = "1"
 serde_json = "1"
-twox-hash = "1"
+twox-hash = { version = "2", default-features = false, features = ["xxhash64"] }
 url = "2.1"
 
 [dependencies.native-tls]

--- a/src/conn/stmt_cache.rs
+++ b/src/conn/stmt_cache.rs
@@ -7,7 +7,7 @@
 // modified, or distributed except according to those terms.
 
 use lru::LruCache;
-use twox_hash::XxHash;
+use twox_hash::XxHash64;
 
 use std::{
     borrow::Borrow,
@@ -42,7 +42,7 @@ pub struct Entry {
 pub struct StmtCache {
     cap: usize,
     cache: LruCache<u32, Entry>,
-    query_map: HashMap<QueryString, u32, BuildHasherDefault<XxHash>>,
+    query_map: HashMap<QueryString, u32, BuildHasherDefault<XxHash64>>,
 }
 
 impl StmtCache {


### PR DESCRIPTION
Thanks for using my crate!

Note that version 2.0 increases the MSRV to Rust 1.81. I understand if you don't want to upgrade right away, but hopefully this PR will be useful when you do.

I'm opening these PRs for the top users of twox-hash and have no current plans to become a consistent contributor to this specific repository; please feel free to rewrite the commit as appropriate for your project's requirements.