### PR TITLE
Fix PoolConstraints infinite wait when the max value Is zero

### DIFF
--- a/src/conn/opts/pool_opts.rs
+++ b/src/conn/opts/pool_opts.rs
@@ -169,10 +169,10 @@ impl PoolConstraints {
     /// # Ok(()) }
     /// ```
     pub fn new(min: usize, max: usize) -> Option<PoolConstraints> {
-        if min <= max {
-            Some(PoolConstraints { min, max })
-        } else {
-            None
+        match (min, max) {
+            (0, 0) => None,
+            (min, max) if min <= max => Some(PoolConstraints { min, max }),
+            _ => None,
         }
     }
 

--- a/src/conn/opts/pool_opts.rs
+++ b/src/conn/opts/pool_opts.rs
@@ -140,6 +140,16 @@ const_assert!(
     PoolConstraints::DEFAULT.min <= PoolConstraints::DEFAULT.max,
 );
 
+const_assert!(
+    _POOL_CONSTRAINTS_MIN_IS_NONZERO,
+    PoolConstraints::DEFAULT.min > 0
+);
+
+const_assert!(
+    _POOL_CONSTRAINTS_MAX_IS_NONZERO,
+    PoolConstraints::DEFAULT.max > 0
+);
+
 pub struct Assert<const L: usize, const R: usize>;
 impl<const L: usize, const R: usize> Assert<L, R> {
     pub const LEQ: usize = R - L;
@@ -178,6 +188,10 @@ impl PoolConstraints {
 
     pub const fn new_const<const MIN: usize, const MAX: usize>() -> PoolConstraints {
         gte::<MIN, MAX>();
+
+        assert!(MIN > 0);
+        assert!(MAX > 0);
+
         PoolConstraints { min: MIN, max: MAX }
     }
 

--- a/src/conn/pool/mod.rs
+++ b/src/conn/pool/mod.rs
@@ -499,6 +499,12 @@ mod test {
         }
 
         #[test]
+        fn should_be_none_if_pool_size_zero_zero() {
+            let pool_constraints = PoolConstraints::new(0, 0);
+            assert!(pool_constraints.is_none());
+        }
+
+        #[test]
         fn should_execute_statements_on_PooledConn() {
             let pool = Pool::new(get_opts()).unwrap();
             let mut threads = Vec::new();

--- a/src/conn/pool/mod.rs
+++ b/src/conn/pool/mod.rs
@@ -505,6 +505,12 @@ mod test {
         }
 
         #[test]
+        #[should_panic]
+        fn should_panic_if_pool_size_zero_zero() {
+            PoolConstraints::new_const::<0, 0>();
+        }
+
+        #[test]
         fn should_execute_statements_on_PooledConn() {
             let pool = Pool::new(get_opts()).unwrap();
             let mut threads = Vec::new();


### PR DESCRIPTION
I've created issue #397 and am submitting a PR that adds effective tests.  
In summary, if you set the pool size using `PoolConstraints::new(0, 0)`, the connection will wait indefinitely.

I've added two tests to verify this behavior at runtime and at compile time:
- `PoolConstraints::new(0, 0);`
- `PoolConstraints::new_const::<0, 0>();`

Please review. Thank you.