### PR TITLE
Issue #401 Support of MariaDB prepared statement metadata caching.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,3 +96,7 @@ named_pipe = "~0.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[patch.crates-io]
+mysql_common = { git = "https://github.com/lawrinn/rust_mysql_common", branch = "master" }
+#mysql_common = { path = "../mysql-common" }

--- a/src/conn/query_result.rs
+++ b/src/conn/query_result.rs
@@ -142,6 +142,14 @@ impl<'c, 't, 'tc, T: crate::prelude::Protocol> QueryResult<'c, 't, 'tc, T> {
         Self::from_state(conn, meta.into())
     }
 
+    pub(crate) fn new_from_cached_metadata(
+        conn: ConnMut<'c, 't, 'tc>,
+        columns: &[Column],
+    ) -> QueryResult<'c, 't, 'tc, T> {
+        let owned_vec = columns.to_vec();
+        let meta: Or<Vec<Column>, OkPacket<'static>> = Or::A(owned_vec);
+        Self::from_state(conn, meta.into())
+    }
     /// Updates state with the next result set, if any.
     ///
     /// Returns `false` if there is no next result set.


### PR DESCRIPTION
This is the part of the implementation of the https://github.com/blackbeam/rust-mysql-simple/issues/401

The fix sends metadata caching extended capability flag if server set it too. If this extended MariaDB capability flag is set, it expects that there can be no metadata in the Ok packet and uses for query result the metadata from prepare.
The patch contains the test for metadata consistency and covers among others the case when metadata is different after prepare and after execute("SELECT ?").

Since the fix relies on the fix in mysql_common that is not yet [merged,](https://github.com/blackbeam/rust_mysql_common/pull/171) the patch currently changes Cargo.toml to use mysql_common from my fork.

The PR is submitted on behalf of my employer, MariaDB Corporation plc. We are planning further support and implement MariaDB specific features.