### PR TITLE
Adding MariaDB bulk execution functionality.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,3 +97,6 @@ named_pipe = "~0.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[patch.crates-io]
+mysql_common = { git = "https://github.com/lawrinn/rust_mysql_common", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ binlog = ["mysql_common/binlog"]
 client_ed25519 = ["mysql_common/client_ed25519"]
 
 [dev-dependencies]
-mysql_common = { version = "0.36.0", features = ["time", "frunk"] }
+mysql_common = { version = "0.36.2", features = ["time", "frunk"] }
 rand = "0.8.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -80,7 +80,7 @@ crossbeam-utils = "0.8.21"
 flate2 = { version = "1.0", default-features = false }
 io-enum = "1.0.0"
 lru = { version = "0.12", default-features = false }
-mysql_common = { version = "0.36.0", default-features = false }
+mysql_common = { version = "0.36.2", default-features = false }
 native-tls = { version = "0.2.3", optional = true }
 pem = "3"
 percent-encoding = "2.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ binlog = ["mysql_common/binlog"]
 client_ed25519 = ["mysql_common/client_ed25519"]
 
 [dev-dependencies]
-mysql_common = { version = "0.35.4", features = ["time", "frunk"] }
+mysql_common = { version = "0.36.0", features = ["time", "frunk"] }
 rand = "0.8.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -80,7 +80,7 @@ crossbeam-utils = "0.8.21"
 flate2 = { version = "1.0", default-features = false }
 io-enum = "1.0.0"
 lru = { version = "0.12", default-features = false }
-mysql_common = { version = "0.35.5", default-features = false }
+mysql_common = { version = "0.36.0", default-features = false }
 native-tls = { version = "0.2.3", optional = true }
 pem = "3"
 percent-encoding = "2.1.0"
@@ -97,6 +97,3 @@ named_pipe = "~0.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-
-[patch.crates-io]
-mysql_common = { git = "https://github.com/lawrinn/rust_mysql_common", branch = "master" }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
 
   - job: "TestBasicMacOs"
     pool:
-      vmImage: "macOS-13"
+      vmImage: "macOS-latest"
     strategy:
       maxParallel: 10
       matrix:
@@ -59,7 +59,7 @@ jobs:
 
   - job: "TestBasicWindows"
     pool:
-      vmImage: "windows-2019"
+      vmImage: "windows-latest"
     strategy:
       maxParallel: 10
       matrix:

--- a/src/conn/local_infile.rs
+++ b/src/conn/local_infile.rs
@@ -125,7 +125,7 @@ impl io::Write for LocalInfile<'_> {
             let mut range = &self.buffer.get_ref()[..n];
             self.conn
                 .write_packet(&mut range)
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, Box::new(e)))?;
+                .map_err(io::Error::other)?;
         }
         self.buffer.set_position(0);
         Ok(())

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -328,7 +328,7 @@ impl Conn {
     /// Will be empty if not defined.
     ///
     /// [Info]: http://dev.mysql.com/doc/internals/en/packet-OK_Packet.html
-    pub fn info_str(&self) -> Cow<str> {
+    pub fn info_str(&self) -> Cow<'_, str> {
         self.0
             .ok_packet
             .as_ref()
@@ -615,7 +615,7 @@ impl Conn {
         self.0.character_set = hp.default_collation();
         self.0.server_version = hp.server_version_parsed();
         self.0.mariadb_server_version = hp.maria_db_server_version_parsed();
-        // If we have a MariaDB server version, we are using mariadb extended capbilities from the handshake packet.
+        // If we have a MariaDB server version, we are using mariadb extended capabilities from the handshake packet.
         // MariaDB does not set 1 standard capability flag bit to indicate that it supports extended capabilities.
         if self.0.mariadb_server_version.is_some()
             && !self
@@ -1199,7 +1199,7 @@ impl Conn {
 
     /// Starts new transaction with provided options.
     /// `readonly` is only available since MySQL 5.6.5.
-    pub fn start_transaction(&mut self, tx_opts: TxOpts) -> Result<Transaction> {
+    pub fn start_transaction(&mut self, tx_opts: TxOpts) -> Result<Transaction<'_>> {
         self._start_transaction(tx_opts)?;
         Ok(Transaction::new(self.into()))
     }
@@ -2838,7 +2838,7 @@ mod test {
 
             // Calculate a row size that will make the total packet size > max_allowed_packet
             // Packet will have 4 byte header and 7 bytes COM_STMT_BULK_EXECUTE fields + 4 bytes for parameter types
-            // 8 bytes per row for id + 2 bytes for indicators + 3 bytes for lenngth encoding of val.
+            // 8 bytes per row for id + 2 bytes for indicators + 3 bytes for length encoding of val.
             let num_rows = 3;
             let row_chunk_size = CLIENT_MAX_PACKET_SIZE / num_rows;
             let mut row_data_1 = "a".repeat(row_chunk_size);

--- a/src/conn/opts/mod.rs
+++ b/src/conn/opts/mod.rs
@@ -331,7 +331,7 @@ impl Opts {
     }
 
     /// Address of mysql server (defaults to `127.0.0.1`). Host names should also work.
-    pub fn get_ip_or_hostname(&self) -> Cow<str> {
+    pub fn get_ip_or_hostname(&self) -> Cow<'_, str> {
         self.0.ip_or_hostname.to_string().into()
     }
     /// TCP port of mysql server (defaults to `3306`).

--- a/src/conn/pool/mod.rs
+++ b/src/conn/pool/mod.rs
@@ -338,6 +338,16 @@ impl Queryable for PooledConn {
     {
         self.conn.as_mut().unwrap().exec_iter(stmt, params)
     }
+
+    fn exec_batch<S, P, I>(&mut self, stmt: S, params: I) -> Result<()>
+    where
+        Self: Sized,
+        S: AsStatement,
+        P: Into<Params>,
+        I: IntoIterator<Item = P>,
+    {
+        self.conn.as_mut().unwrap().exec_batch(stmt, params)
+    }
 }
 
 #[cfg(test)]

--- a/src/conn/pool/mod.rs
+++ b/src/conn/pool/mod.rs
@@ -254,7 +254,7 @@ impl Drop for PooledConn {
 impl PooledConn {
     /// Redirects to
     /// [`Conn#start_transaction`](struct.Conn.html#method.start_transaction)
-    pub fn start_transaction(&mut self, tx_opts: TxOpts) -> Result<Transaction> {
+    pub fn start_transaction(&mut self, tx_opts: TxOpts) -> Result<Transaction<'_>> {
         self.conn.as_mut().unwrap().start_transaction(tx_opts)
     }
 

--- a/src/conn/query.rs
+++ b/src/conn/query.rs
@@ -384,7 +384,7 @@ where
         for params in self.params {
             let params = params.into();
             let info = conn._execute(&statement, params)?;
-            let meta = info.into_statement_meta(&*conn, &statement);
+            let meta = info.into_statement_meta(&conn, &statement);
             let mut query_result = QueryResult::<Binary>::new((&mut *conn).into(), meta);
             while let Some(result_set) = query_result.iter() {
                 for row in result_set {

--- a/src/conn/query_result.rs
+++ b/src/conn/query_result.rs
@@ -285,7 +285,7 @@ impl<'c, 't, 'tc, T: crate::prelude::Protocol> QueryResult<'c, 't, 'tc, T> {
     /// Will be empty if not defined.
     ///
     /// [Info]: http://dev.mysql.com/doc/internals/en/packet-OK_Packet.html
-    pub fn info_str(&self) -> Cow<str> {
+    pub fn info_str(&self) -> Cow<'_, str> {
         self.state
             .ok_packet()
             .and_then(|ok| ok.info_str())
@@ -293,9 +293,9 @@ impl<'c, 't, 'tc, T: crate::prelude::Protocol> QueryResult<'c, 't, 'tc, T> {
     }
 
     /// Returns columns of the current result rest.
-    pub fn columns(&self) -> SetColumns {
+    pub fn columns(&self) -> SetColumns<'_> {
         SetColumns {
-            inner: self.state.columns().map(Into::into),
+            inner: self.state.columns(),
         }
     }
 }

--- a/src/conn/query_result.rs
+++ b/src/conn/query_result.rs
@@ -103,6 +103,7 @@ impl From<ResultSetMeta> for SetIteratorState {
     }
 }
 
+#[derive(Debug)]
 pub(crate) enum ResultSetMeta {
     Empty(OkPacket<'static>),
     NonEmptyWithMeta(Arc<[Column]>),

--- a/src/conn/queryable.rs
+++ b/src/conn/queryable.rs
@@ -143,6 +143,14 @@ pub trait Queryable {
         P: Into<Params>;
 
     /// Prepares the given statement, and executes it with each item in the given params iterator.
+    ///
+    /// # Note
+    ///
+    /// It will use `COM_STMT_BULK_EXECUTE` for MariaDb >= v10.2. Practically
+    /// this means that the function will error with code 1295 (`ER_UNSUPPORTED_PS`)
+    /// for _non-bulk execution safe_ operations, namely for all operations
+    /// except UPDATE, multi-UPDATE, INSERT, DELETE and REPLACE. Consider not
+    /// using exec batch for operations outside of this list.
     fn exec_batch<S, P, I>(&mut self, stmt: S, params: I) -> Result<()>
     where
         Self: Sized,

--- a/src/conn/queryable.rs
+++ b/src/conn/queryable.rs
@@ -148,15 +148,7 @@ pub trait Queryable {
         Self: Sized,
         S: AsStatement,
         P: Into<Params>,
-        I: IntoIterator<Item = P>,
-    {
-        let stmt = stmt.as_statement(self)?;
-        for params in params {
-            self.exec_drop(stmt.as_ref(), params)?;
-        }
-
-        Ok(())
-    }
+        I: IntoIterator<Item = P>;
 
     /// Executes the given `stmt` and collects the first result set.
     fn exec<T, S, P>(&mut self, stmt: S, params: P) -> Result<Vec<T>>

--- a/src/conn/stmt.rs
+++ b/src/conn/stmt.rs
@@ -137,7 +137,7 @@ impl AsStatement for Statement {
     }
 }
 
-impl<'a> AsStatement for &'a Statement {
+impl AsStatement for &'_ Statement {
     fn as_statement<Q: Queryable>(&self, _queryable: &mut Q) -> Result<Cow<'_, Statement>> {
         Ok(Cow::Borrowed(self))
     }

--- a/src/conn/transaction.rs
+++ b/src/conn/transaction.rs
@@ -164,7 +164,7 @@ impl Transaction<'_> {
     /// Will be empty if not defined.
     ///
     /// [Info]: http://dev.mysql.com/doc/internals/en/packet-OK_Packet.html
-    pub fn info_str(&self) -> Cow<str> {
+    pub fn info_str(&self) -> Cow<'_, str> {
         self.conn.info_str()
     }
 }

--- a/src/conn/transaction.rs
+++ b/src/conn/transaction.rs
@@ -189,6 +189,16 @@ impl<'a> Queryable for Transaction<'a> {
     {
         self.conn.exec_iter(stmt, params)
     }
+
+    fn exec_batch<S, P, I>(&mut self, stmt: S, params: I) -> Result<()>
+    where
+        Self: Sized,
+        S: AsStatement,
+        P: Into<Params>,
+        I: IntoIterator<Item = P>,
+    {
+        self.conn.exec_batch(stmt, params)
+    }
 }
 
 impl<'a> Drop for Transaction<'a> {

--- a/src/io/tcp.rs
+++ b/src/io/tcp.rs
@@ -124,7 +124,7 @@ impl<T: ToSocketAddrs> MyTcpBuilder<T> {
         } else {
             "could not connect to any address with specified bind address"
         };
-        let err = io::Error::new(io::ErrorKind::Other, err_msg);
+        let err = io::Error::other(err_msg);
 
         let addrs = address.to_socket_addrs()?.collect::<Vec<_>>();
 


### PR DESCRIPTION
If the server is not MariaDB exec_batch is executed the old way. 
The method _execute_bulk in connection executes MariaDB COM_STMT_BULK_EXECUTE command.

exec_batch method implementation has been moved to all queryable classes.

The test has been added as I've found none for exec_batch. Probably I'll extend it.

Client MariaDB capabilities flag now contains MARIADB_CLIENT_STMT_BULK_OPERATIONS

mysql_common is pointing to my repo as the require change there has not been merged yet.

Technically, if exec_batch also prepares the query it can be further optimized a little bit using MariaDB stmt_id=-1 feature, but I think that is the matter for a separate PR, as it possibly can be used in other places as well and in exec_batch its effect is probably less noticeable.

This  PR is made on behalf of my employer, MariaDB Corporation plc.