### PR TITLE
Support of authentication using MariaDB Parsec plugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ rust_decimal = ["mysql_common/rust_decimal"]
 frunk = ["mysql_common/frunk"]
 binlog = ["mysql_common/binlog"]
 client_ed25519 = ["mysql_common/client_ed25519"]
+client_parsec = ["mysql_common/client_parsec"]
 
 [dev-dependencies]
 mysql_common = { version = "0.36.2", features = ["time", "frunk"] }
@@ -97,3 +98,6 @@ named_pipe = "~0.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[patch.crates-io]
+mysql_common = { git = "https://github.com/lawrinn/rust_mysql_common", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ client_ed25519 = ["mysql_common/client_ed25519"]
 client_parsec = ["mysql_common/client_parsec"]
 
 [dev-dependencies]
-mysql_common = { version = "0.36.2", features = ["time", "frunk"] }
+mysql_common = { version = "0.37.0", features = ["time", "frunk"] }
 rand = "0.9.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -81,7 +81,7 @@ crossbeam-utils = "0.8.21"
 flate2 = { version = "1.0", default-features = false }
 io-enum = "1.0.0"
 lru = { version = "0.16.3", default-features = false }
-mysql_common = { version = "0.36.2", default-features = false }
+mysql_common = { version = "0.37.0", default-features = false }
 native-tls = { version = "0.2.3", optional = true }
 pem = "3"
 percent-encoding = "2.1.0"
@@ -98,6 +98,3 @@ named_pipe = "~0.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-
-[patch.crates-io]
-mysql_common = { git = "https://github.com/lawrinn/rust_mysql_common", branch = "master" }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -254,6 +254,7 @@ jobs:
                   --ssl-cert=/root/tests/server.crt \
                   --ssl-key=/root/tests/server-key.pem \
                   --secure-auth=OFF \
+                  --plugin-load-add=auth_parsec \
                   --plugin-load-add=auth_ed25519 &
           while ! docker exec container healthcheck.sh --connect --innodb_initialized ; do sleep 1; echo waiting; done
           docker logs container
@@ -266,16 +267,16 @@ jobs:
           docker exec container bash -l -c "curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable"
         displayName: Install Rust in docker
       - bash: |
-          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL cargo test --features client_ed25519"
-          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL COMPRESS=true cargo test --features client_ed25519"
-          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true cargo test --features native-tls,client_ed25519"
-          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true COMPRESS=true cargo test --features native-tls,client_ed25519"
+          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL cargo test --features client_ed25519,client_parsec"
+          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL COMPRESS=true cargo test --features client_ed25519,client_parsec"
+          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true cargo test --features native-tls,client_ed25519,client_parsec"
+          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true COMPRESS=true cargo test --features native-tls,client_ed25519,client_parsec"
 
-          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true COMPRESS=false cargo test --no-default-features --features rustls-tls,minimal-rust,time,frunk,binlog,client_ed25519"
-          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true COMPRESS=true cargo test --no-default-features --features rustls-tls-ring,minimal-rust,time,frunk,binlog,client_ed25519"
+          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true COMPRESS=false cargo test --no-default-features --features rustls-tls,minimal-rust,time,frunk,binlog,client_ed25519,client_parsec"
+          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=true COMPRESS=true cargo test --no-default-features --features rustls-tls-ring,minimal-rust,time,frunk,binlog,client_ed25519,client_parsec"
 
-          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=false COMPRESS=true cargo test --no-default-features --features minimal,time,frunk,binlog,client_ed25519"
-          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=false COMPRESS=false cargo test --no-default-features --features minimal,time,frunk,binlog,client_ed25519"
+          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=false COMPRESS=true cargo test --no-default-features --features minimal,time,frunk,binlog,client_ed25519,client_parsec"
+          docker exec container bash -l -c "cd \$HOME && DATABASE_URL=$DATABASE_URL SSL=false COMPRESS=false cargo test --no-default-features --features minimal,time,frunk,binlog,client_ed25519,client_parsec"
         env:
           RUST_BACKTRACE: 1
           DATABASE_URL: mysql://root:password@localhost/mysql

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -219,16 +219,6 @@ jobs:
           CONTAINER: "quay.io/mariadb-foundation/mariadb-devel:latest"
         lts:
           CONTAINER: "mariadb:lts"
-        v1106:
-          CONTAINER: "mariadb:11.6"
-        v1105:
-          CONTAINER: "mariadb:11.5"
-        v1104:
-          CONTAINER: "mariadb:11.4"
-        v1103:
-          CONTAINER: "mariadb:11.3"
-        v1011:
-          CONTAINER: "mariadb:10.11.10"
     steps:
       - bash: |
           sudo apt-get update

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -3016,6 +3016,7 @@ mod test {
                     get_opts()
                         .user(Some("parsec_test_user"))
                         .pass(Some(pass))
+                        .db_name(None::<String>)
                         .init(vec![] as Vec<String>),
                 )
                 .unwrap();

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -2081,7 +2081,7 @@ mod test {
                 ),
                 (
                     "parsec",
-                    |is_mariadb, version| is_mariadb && version >= (11, 4, 1),
+                    |is_mariadb, version| is_mariadb && version >= (11, 6, 0),
                     |_is_mariadb, _version, pass| {
                         vec![format!(
                             "CREATE USER '__mats'@'%' IDENTIFIED WITH parsec AS PASSWORD('{pass}')"
@@ -2987,7 +2987,7 @@ mod test {
             let mut conn = Conn::new(get_opts()).unwrap();
             let is_mariadb = conn.0.mariadb_server_version.is_some();
             let version = conn.server_version();
-            if is_mariadb && version >= (11, 4, 1) {
+            if is_mariadb && version >= (11, 6, 0) {
                 // Creating random password so in case of test failure user won't have
                 // known password left behind.
                 let mut rng = rand::rng();

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -223,6 +223,7 @@ pub enum DriverError {
     OldMysqlPasswordDisabled,
     CleartextPluginDisabled,
     BulkExecute(BulkExecuteRequestError),
+    InvalidParsecSalt,
 }
 
 impl From<BulkExecuteRequestBuilderError> for DriverError {
@@ -307,6 +308,9 @@ impl fmt::Display for DriverError {
             }
             DriverError::BulkExecute(e) => {
                 write!(f, "Bulk execute error: {e}")
+            }
+            DriverError::InvalidParsecSalt => {
+                write!(f, "Could not parse Parsec extended salt packet")
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1069,8 +1069,6 @@ macro_rules! doctest_wrapper {
 
 #[cfg(test)]
 mod test_misc {
-    use crate::{def_database_url, def_get_opts};
-
     #[allow(dead_code)]
     fn error_should_implement_send_and_sync() {
         fn _dummy<T: Send + Sync>(_: T) {}


### PR DESCRIPTION
Actual support is enabled by `client_parsec` feature.

Introduced new test 'parsec_connect' that is also enabled by before-mentioned feature. To the test 'should_change_user' added covering of the case when user authenticated via parsec plugin.

Most of the logic of the work with the plugin is in the method continue_parsec_auth
 perform_auth_switch sends additional empty packet to request ext-salt packet. After that continue_parsec_auth calls AuthPlugin methods to read that packet info and to generate response.