### PR TITLE
Support of the MariaDB "Zero config SSL" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ rustls = [
     "webpki-roots",
     "rustls-pemfile",
     "dep:sha2",
+    "dep:x509-parser"
 ]
 
 # global buffer pool
@@ -67,7 +68,7 @@ client_ed25519 = ["mysql_common/client_ed25519"]
 client_parsec = ["mysql_common/client_parsec"]
 
 [dev-dependencies]
-mysql_common = { version = "0.37.3", features = ["time", "frunk"] }
+mysql_common = { version = "0.38.0", features = ["time", "frunk"] }
 rand = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -82,7 +83,7 @@ crossbeam-utils = "0.8.21"
 flate2 = { version = "1.0", default-features = false }
 io-enum = "1.0.0"
 lru = { version = "0.16.3", default-features = false }
-mysql_common = { version = "0.37.3", default-features = false }
+mysql_common = { version = "0.38.0", default-features = false }
 native-tls = { version = "0.2.3", optional = true }
 pem = "3"
 percent-encoding = "2.1.0"
@@ -94,13 +95,10 @@ twox-hash = { version = "2", default-features = false, features = ["xxhash64"] }
 url = "2.1"
 webpki = { version = "0.22", features = ["std"], optional = true }
 webpki-roots = { version = "1.0.5", optional = true }
+x509-parser = { version = "0.18", optional = true}
 
 [target.'cfg(target_os = "windows")'.dependencies]
 named_pipe = "~0.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-
-[patch.crates-io]
-mysql_common = { git = "https://github.com/lawrinn/rust_mysql_common", branch = "zero_config_tls" }
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ client_ed25519 = ["mysql_common/client_ed25519"]
 client_parsec = ["mysql_common/client_parsec"]
 
 [dev-dependencies]
-mysql_common = { version = "0.38.0", features = ["time", "frunk"] }
+mysql_common = { version = "0.38.2", features = ["time", "frunk"] }
 rand = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -83,7 +83,7 @@ crossbeam-utils = "0.8.21"
 flate2 = { version = "1.0", default-features = false }
 io-enum = "1.0.0"
 lru = { version = "0.16.3", default-features = false }
-mysql_common = { version = "0.38.0", default-features = false }
+mysql_common = { version = "0.38.2", default-features = false }
 native-tls = { version = "0.2.3", optional = true }
 pem = "3"
 percent-encoding = "2.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ rand = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 time = "0.3"
-frunk = "0.4"
+frunk = ">=0.5, <0.6"
 
 [dependencies]
 bufstream = "~0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ rustls = [
     "webpki",
     "webpki-roots",
     "rustls-pemfile",
+    "dep:sha2",
 ]
 
 # global buffer pool
@@ -66,7 +67,7 @@ client_ed25519 = ["mysql_common/client_ed25519"]
 client_parsec = ["mysql_common/client_parsec"]
 
 [dev-dependencies]
-mysql_common = { version = "0.37.0", features = ["time", "frunk"] }
+mysql_common = { version = "0.37.3", features = ["time", "frunk"] }
 rand = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -81,12 +82,13 @@ crossbeam-utils = "0.8.21"
 flate2 = { version = "1.0", default-features = false }
 io-enum = "1.0.0"
 lru = { version = "0.16.3", default-features = false }
-mysql_common = { version = "0.37.0", default-features = false }
+mysql_common = { version = "0.37.3", default-features = false }
 native-tls = { version = "0.2.3", optional = true }
 pem = "3"
 percent-encoding = "2.1.0"
 rustls = { version = "0.23", optional = true, default-features = false }
 rustls-pemfile = { version = "2.1", optional = true }
+sha2 = { version = "0.10.0", optional = true }
 socket2 = "0.6.1"
 twox-hash = { version = "2", default-features = false, features = ["xxhash64"] }
 url = "2.1"
@@ -98,3 +100,7 @@ named_pipe = "~0.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[patch.crates-io]
+mysql_common = { git = "https://github.com/lawrinn/rust_mysql_common", branch = "zero_config_tls" }
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -258,7 +258,6 @@ jobs:
           docker --version
         displayName: Install docker
       - bash: |
-          if [[ "mariadb:lts" == "$(CONTAINER)" ]]; then ARG="--ssl-ca=/root/tests/ca.crt --ssl-cert=/root/tests/server.crt --ssl-key=/root/tests/server-key.pem"; fi
           docker run --rm -d \
               --name container \
               -v `pwd`:/root \
@@ -271,7 +270,6 @@ jobs:
                   --log-bin=mysql-bin --gtid-domain-id=1 \
                   --server-id=1 \
                   --ssl \
-                  $ARG \
                   --secure-auth=OFF \
                   --plugin-load-add=auth_parsec \
                   --plugin-load-add=auth_ed25519 &

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -191,6 +191,17 @@ jobs:
           while ! nc -W 1 localhost 3307 | grep -q -P '.+'; do sleep 1; done
         displayName: Run MySql in Docker
       - bash: |
+          docker exec container bash -l -c "echo 'deb http://archive.debian.org/debian buster main' > /etc/apt/sources.list"
+          docker exec container bash -l -c "echo 'deb http://archive.debian.org/debian buster-updates main' >> /etc/apt/sources.list"
+          docker exec container bash -l -c "echo 'deb http://archive.debian.org/debian-security buster/updates main contrib non-free' >> /etc/apt/sources.list"
+          docker exec container bash -l -c "echo 'Acquire::AllowInsecureRepositories \"true\";' > /etc/apt/apt.conf.d/99allow-insecure"
+          docker exec container bash -l -c "echo 'Acquire::AllowUnsignedRepositories \"true\";' >> /etc/apt/apt.conf.d/99allow-insecure"
+          docker exec container bash -l -c "echo 'Acquire::https::Verify-Peer \"false\";' > /etc/apt/apt.conf.d/99ignore-ssl"
+          docker exec container bash -l -c "echo 'Acquire::https::Verify-Host \"false\";' >> /etc/apt/apt.conf.d/99ignore-ssl"
+          docker exec container bash -l -c "echo 'Acquire::Check-Valid-Until \"false\";' >> /etc/apt/apt.conf.d/99ignore-ssl"
+          docker exec container bash -l -c "echo 'Acquire::Check-Valid-Until \"false\";' > /etc/apt/apt.conf.d/99no-check-valid-until"
+        condition: eq(variables['DB_VERSION'], '5.7-debian')
+      - bash: |
           docker exec container bash -l -c "mysql -uroot -ppassword -e \"SET old_passwords = 1; GRANT ALL PRIVILEGES ON *.* TO 'root2'@'%' IDENTIFIED WITH mysql_old_password AS 'password'; SET PASSWORD FOR 'root2'@'%' = OLD_PASSWORD('password')\"";
           docker exec container bash -l -c "echo 'deb [trusted=yes] http://archive.debian.org/debian/ stretch main non-free contrib' > /etc/apt/sources.list"
           docker exec container bash -l -c "echo 'deb-src [trusted=yes] http://archive.debian.org/debian/ stretch main non-free contrib ' >> /etc/apt/sources.list"
@@ -247,6 +258,7 @@ jobs:
           docker --version
         displayName: Install docker
       - bash: |
+          if [[ "mariadb:lts" == "$(CONTAINER)" ]]; then ARG="--ssl-ca=/root/tests/ca.crt --ssl-cert=/root/tests/server.crt --ssl-key=/root/tests/server-key.pem"; fi
           docker run --rm -d \
               --name container \
               -v `pwd`:/root \
@@ -259,9 +271,7 @@ jobs:
                   --log-bin=mysql-bin --gtid-domain-id=1 \
                   --server-id=1 \
                   --ssl \
-                  --ssl-ca=/root/tests/ca.crt \
-                  --ssl-cert=/root/tests/server.crt \
-                  --ssl-key=/root/tests/server-key.pem \
+                  $ARG \
                   --secure-auth=OFF \
                   --plugin-load-add=auth_parsec \
                   --plugin-load-add=auth_ed25519 &

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -10,6 +10,7 @@ use bytes::{Buf, BufMut};
 #[cfg(feature = "binlog")]
 use mysql_common::packets::binlog_request::BinlogRequest;
 use mysql_common::{
+    auth::{self, plugins::ChallengeResponsePlugin as _},
     constants::UTF8MB4_GENERAL_CI,
     crypto::{self, MariaDbZeroConfigCheck},
     io::{ParseBuf, ReadMysqlExt},
@@ -33,7 +34,8 @@ use std::{
     borrow::{Borrow, Cow},
     collections::HashMap,
     convert::TryFrom,
-    io::{self, Write as _},
+    fs::File,
+    io::{self, Read as _, Write as _},
     mem,
     ops::{Deref, DerefMut},
     process,
@@ -61,7 +63,7 @@ use crate::{
     DriverError::{
         CertificateCannotBeValidated, CleartextPluginDisabled, MismatchedStmtParams,
         OldMysqlPasswordDisabled, Protocol41NotSet, ReadOnlyTransNotSupported, SetupError,
-        UnexpectedPacket, UnknownAuthPlugin, UnsupportedProtocol,
+        UnexpectedPacket, UnsupportedProtocol,
     },
     Error::{self, DriverError, MySqlError},
     LocalInfileHandler, Opts, OptsBuilder, Params, QueryResult, Result, Transaction,
@@ -219,10 +221,12 @@ struct ConnInner {
     has_results: bool,
     local_infile_handler: Option<LocalInfileHandler>,
 
+    // Cached public server key used for RSA-based key exchange by the caching_sha2_password plugin.
+    server_key_pem: Option<Option<Vec<u8>>>,
+
     auth_plugin: AuthPlugin<'static>,
+    // Handshake packet nonce
     nonce: Vec<u8>,
-    // To preserve scramble if it gets overwritten during auth switch, as it's needed for MariaDB "zero-config TLS" fallback validation.
-    scramble: Option<[u8; 20]>,
     // This is passed to TLS certificate verifier as a flag if zero-config validation is possible for this connection.
     // If so, the verifier will store the info required to complete the validation and this will be also the flag that such validation is pending.
     zero_config_check: Option<Arc<Mutex<Option<MariaDbZeroConfigCheck>>>>,
@@ -279,9 +283,9 @@ impl ConnInner {
             local_infile_handler: None,
             auth_plugin: AuthPlugin::MysqlNativePassword,
             nonce: Vec::new(),
-            scramble: None,
             zero_config_check: None,
             reset_upon_return: opts.get_pool_opts().reset_connection(),
+            server_key_pem: None,
 
             opts,
         }
@@ -293,7 +297,9 @@ impl ConnInner {
 pub struct Conn(Box<ConnInner>);
 
 impl Conn {
-    // Returns true if MariaDB zero-config fallback is currently pending (i.e., certificate validation is required).
+    /// Returns true if MariaDB zero-config fallback is currently pending (i.e., certificate validation is required).
+    ///
+    /// This makes connection insecure even though the transport is TLS.
     fn zero_config_fallback_pending(&self) -> bool {
         self.0
             .zero_config_check
@@ -323,6 +329,7 @@ impl Conn {
                 })
             })
     }
+
     /// Must not be called before handle_handshake.
     const fn has_capability(&self, flag: CapabilityFlags) -> bool {
         self.0.capability_flags.contains(flag)
@@ -418,12 +425,16 @@ impl Conn {
         self.0.stream.as_mut().expect("incomplete connection")
     }
 
-    fn is_insecure(&self) -> bool {
-        self.stream_ref().get_ref().is_insecure()
+    fn is_tls_connection(&self) -> bool {
+        self.stream_ref().get_ref().is_secure() && !self.zero_config_fallback_pending()
     }
 
-    fn is_socket(&self) -> bool {
+    fn is_socket_connection(&self) -> bool {
         self.stream_ref().get_ref().is_socket()
+    }
+
+    fn is_cleartext_connection(&self) -> bool {
+        self.stream_ref().get_ref().is_insecure()
     }
 
     /// Check the connection can be improved.
@@ -489,17 +500,45 @@ impl Conn {
         Ok(())
     }
 
+    fn auth_context(&mut self) -> Result<AuthContext> {
+        // cache server key
+        if self.0.server_key_pem.is_none() {
+            if let Some(server_key_path) = self.0.opts.get_server_key_path() {
+                let mut server_key_data = vec![];
+                let mut server_key_file = File::open(server_key_path)?;
+                server_key_file.read_to_end(&mut server_key_data)?;
+                self.0.server_key_pem = Some(Some(server_key_data));
+            } else {
+                self.0.server_key_pem = Some(None);
+            }
+        }
+
+        Ok(AuthContext {
+            pass: self
+                .0
+                .opts
+                .get_pass()
+                .clone()
+                .map(|x| x.into())
+                .unwrap_or_default(),
+            is_tls_transport: self.is_tls_connection(),
+            is_ipc_transport: self.is_socket_connection(),
+            scramble: self.0.nonce.clone(),
+            server_key_pem: self.0.server_key_pem.as_ref().and_then(|x| x.clone()),
+        })
+    }
+
     fn exec_com_change_user(&mut self, opts: ChangeUserOpts) -> Result<()> {
         opts.update_opts(&mut self.0.opts);
+
+        let mut auth_proc = self.0.auth_plugin.init()?;
+        let auth_ctx = self.auth_context()?;
+        let response = auth_proc.run(&auth_ctx, &self.0.nonce)?;
+
         let com_change_user = ComChangeUser::new()
             .with_user(self.0.opts.get_user().map(|x| x.as_bytes()))
             .with_database(self.0.opts.get_db_name().map(|x| x.as_bytes()))
-            .with_auth_plugin_data(
-                self.0
-                    .auth_plugin
-                    .gen_data(self.0.opts.get_pass(), &self.0.nonce)
-                    .as_deref(),
-            )
+            .with_auth_plugin_data(response.data())
             .with_more_data(Some(
                 ComChangeUserMoreData::new(if self.server_version() >= (5, 5, 3) {
                     UTF8MB4_GENERAL_CI
@@ -513,7 +552,10 @@ impl Conn {
         self.write_command_raw(&com_change_user)?;
         self.0.last_command = 0;
         self.0.stmt_cache.clear();
-        self.continue_auth(false)
+
+        self.continue_auth(false, auth_ctx, auth_proc, response)?;
+
+        Ok(())
     }
 
     /// Tries to reset the connection.
@@ -579,6 +621,13 @@ impl Conn {
             .map_or(false, |ver| ver > (11, 4, 0))
             && self.0.opts.get_pass().map_or(false, |p| !p.is_empty())
             && self.0.auth_plugin.supports_password_hash()
+            // MariaDb denies specifying CA for "zero-config TLS"
+            && self
+                .0
+                .opts
+                .get_ssl_opts()
+                .map(|ssl_opts| ssl_opts.root_cert_path().is_none())
+                .unwrap_or_default()
     }
 
     fn switch_to_ssl(&mut self, ssl_opts: SslOpts) -> Result<()> {
@@ -733,7 +782,10 @@ impl Conn {
             .contains(StatusFlags::SERVER_MORE_RESULTS_EXISTS)
     }
 
-    fn perform_auth_switch(&mut self, auth_switch_request: AuthSwitchRequest<'_>) -> Result<()> {
+    fn perform_auth_switch(
+        &mut self,
+        auth_switch_request: AuthSwitchRequest<'_>,
+    ) -> Result<auth::plugins::AuthProc> {
         if matches!(
             auth_switch_request.auth_plugin(),
             AuthPlugin::MysqlOldPassword
@@ -750,57 +802,24 @@ impl Conn {
             return Err(DriverError(CleartextPluginDisabled));
         }
 
-        // If zero-config fallback is pending but auth plugin is not right for it - returning certificate validation error.
-        // Otherwise, storing scramble for later use in certificate validation.
-        if self.zero_config_fallback_pending() {
-            if !auth_switch_request.auth_plugin().supports_password_hash() {
-                self.0.zero_config_check = None;
-                return Err(DriverError(CertificateCannotBeValidated));
-            } else {
-                // Storing scramble as it's used in "zero-config ssl" certificate validation.
-                if let Ok(scramble_arr) = self.0.nonce[..].try_into() {
-                    self.0.scramble = Some(scramble_arr);
-                }
-            }
+        // If MariaDb "zero-config TLS" is in progress, then only supported plugins are allowed
+        #[cfg(feature = "rustls")]
+        if self.zero_config_fallback_pending()
+            && !auth_switch_request.auth_plugin().supports_password_hash()
+        {
+            return Err(
+                rustls::Error::InvalidCertificate(rustls::CertificateError::UnknownIssuer).into(),
+            );
         }
 
-        self.0.nonce = auth_switch_request.plugin_data().to_vec();
-        self.0.auth_plugin = auth_switch_request.auth_plugin().into_owned();
-        let plugin_data = match self.0.auth_plugin {
-            ref mut x @ AuthPlugin::MysqlOldPassword => {
-                if self.0.opts.get_secure_auth() {
-                    return Err(DriverError(OldMysqlPasswordDisabled));
-                }
-                x.gen_data(self.0.opts.get_pass(), &self.0.nonce)
-            }
-            ref mut x @ AuthPlugin::MysqlNativePassword => {
-                x.gen_data(self.0.opts.get_pass(), &self.0.nonce)
-            }
-            ref mut x @ AuthPlugin::CachingSha2Password => {
-                x.gen_data(self.0.opts.get_pass(), &self.0.nonce)
-            }
-            ref mut x @ AuthPlugin::MysqlClearPassword => {
-                if !self.0.opts.get_enable_cleartext_plugin() {
-                    return Err(DriverError(UnknownAuthPlugin(
-                        "mysql_clear_password".into(),
-                    )));
-                }
-
-                x.gen_data(self.0.opts.get_pass(), &self.0.nonce)
-            }
-            ref mut x @ AuthPlugin::Ed25519 => x.gen_data(self.0.opts.get_pass(), &self.0.nonce),
-            // For parsec at this point we need to send an empty packet first
-            ref _x @ AuthPlugin::MariadbParsec { .. } => None,
-            AuthPlugin::Other(_) => None,
-        };
-
-        if let Some(plugin_data) = plugin_data {
-            self.write_struct(&plugin_data.into_owned())?;
-        } else {
-            self.write_packet(&mut &[0_u8; 0][..])?;
+        let auth_ctx = self.auth_context()?;
+        let mut auth_proc = auth_switch_request.auth_plugin().init()?;
+        let response = auth_proc.run(&auth_ctx, auth_switch_request.plugin_data())?;
+        if let Some(mut packet) = response.data() {
+            self.write_packet(&mut packet)?;
         }
 
-        self.continue_auth(true)
+        self.continue_auth(true, auth_ctx, auth_proc, response)
     }
 
     fn do_handshake(&mut self) -> Result<()> {
@@ -822,7 +841,7 @@ impl Conn {
 
         self.handle_handshake(&handshake);
 
-        if self.is_insecure() {
+        if !self.is_socket_connection() {
             if let Some(ssl_opts) = self.0.opts.get_ssl_opts().cloned() {
                 if !self.has_capability(CapabilityFlags::CLIENT_SSL) {
                     return Err(DriverError(TlsNotSupported));
@@ -833,15 +852,7 @@ impl Conn {
             }
         }
 
-        // Handshake scramble is always 21 bytes length (20 + zero terminator)
-        self.0.nonce = {
-            let mut nonce = Vec::from(handshake.scramble_1_ref());
-            nonce.extend_from_slice(handshake.scramble_2_ref().unwrap_or(&[][..]));
-            // Trim zero terminator. Fill with zeroes if nonce
-            // is somehow smaller than 20 bytes (this matches the server behavior).
-            nonce.resize(20, 0);
-            nonce
-        };
+        self.0.nonce = handshake.nonce();
 
         // Allow only CachingSha2Password and MysqlNativePassword here
         // because sha256_password is deprecated and other plugins won't
@@ -851,8 +862,15 @@ impl Conn {
             _ => AuthPlugin::MysqlNativePassword,
         };
 
-        self.write_handshake_response()?;
-        self.continue_auth(false)?;
+        let auth_ctx = self.auth_context()?;
+        let mut auth_proc = self.0.auth_plugin.init()?;
+        let response = auth_proc.run(&auth_ctx, &self.0.nonce)?;
+
+        self.write_handshake_response(response.data())?;
+        let auth_proc = self.continue_auth(false, auth_ctx, auth_proc, response)?;
+
+        // If authentication was successful, we have evertything to validate the certificate.
+        self.validate_mariadb_certificate_if_needed(auth_proc)?;
 
         if self.has_capability(CapabilityFlags::CLIENT_COMPRESS) {
             self.switch_to_compressed();
@@ -889,7 +907,7 @@ impl Conn {
                 client_flags.insert(CapabilityFlags::CLIENT_CONNECT_WITH_DB);
             }
         }
-        if self.is_insecure() && self.0.opts.get_ssl_opts().is_some() {
+        if self.is_cleartext_connection() && self.0.opts.get_ssl_opts().is_some() {
             client_flags.insert(CapabilityFlags::CLIENT_SSL);
         }
         client_flags | self.0.opts.get_additional_capabilities()
@@ -942,22 +960,17 @@ impl Conn {
         };
 
         let ssl_request = SslRequest::new(
-            self.get_client_flags(),
+            self.0.capability_flags,
             DEFAULT_MAX_ALLOWED_PACKET as u32,
             charset as u8,
-        );
+        )
+        .with_mariadb_capabilities(self.0.mariadb_ext_capabilities);
         self.write_struct(&ssl_request)
     }
 
-    fn write_handshake_response(&mut self) -> Result<()> {
-        let auth_data = self
-            .0
-            .auth_plugin
-            .gen_data(self.0.opts.get_pass(), &self.0.nonce)
-            .map(|x| x.into_owned());
-
+    fn write_handshake_response(&mut self, plugin_response: Option<&[u8]>) -> Result<()> {
         let handshake_response = HandshakeResponse::new(
-            auth_data.as_deref(),
+            plugin_response,
             self.0.server_version.unwrap_or((0, 0, 0)),
             self.0.opts.get_user().map(str::as_bytes),
             self.0.opts.get_db_name().map(str::as_bytes),
@@ -969,56 +982,81 @@ impl Conn {
                 .get_max_allowed_packet()
                 .unwrap_or(DEFAULT_MAX_ALLOWED_PACKET) as u32,
         )
-        .with_mariadb_ext_capabilities(self.0.mariadb_ext_capabilities);
+        .with_mariadb_ext_capabilities(self.get_mariadb_client_flags());
 
         let mut buf = get_buffer();
         handshake_response.serialize(buf.as_mut());
         self.write_packet(&mut &*buf)
     }
 
-    fn continue_auth(&mut self, auth_switched: bool) -> Result<()> {
-        let auth_result = match self.0.auth_plugin {
-            AuthPlugin::CachingSha2Password => {
-                self.continue_caching_sha2_password_auth(auth_switched)?;
-                Ok(())
-            }
-            AuthPlugin::MysqlNativePassword | AuthPlugin::MysqlOldPassword => {
-                self.continue_mysql_native_password_auth(auth_switched)?;
-                Ok(())
-            }
-            AuthPlugin::MysqlClearPassword => {
-                if !self.0.opts.get_enable_cleartext_plugin() {
-                    return Err(DriverError(CleartextPluginDisabled));
-                }
-                self.continue_mysql_native_password_auth(auth_switched)?;
-                Ok(())
-            }
-            AuthPlugin::Ed25519 => {
-                self.continue_ed25519_auth(auth_switched)?;
-                Ok(())
-            }
-            AuthPlugin::MariadbParsec { .. } => {
-                self.continue_parsec_auth(auth_switched)?;
-                Ok(())
-            }
-            AuthPlugin::Other(ref name) => {
-                let plugin_name = String::from_utf8_lossy(name).into();
-                Err(DriverError(UnknownAuthPlugin(plugin_name)))
-            }
-        };
+    /// Returns the completed `AuthProc`.
+    fn continue_auth(
+        &mut self,
+        auth_switched: bool,
+        auth_ctx: AuthContext,
+        mut auth_proc: auth::plugins::AuthProc,
+        mut prev_response: auth::plugins::Response,
+    ) -> Result<auth::plugins::AuthProc> {
+        loop {
+            // read next challenge
+            let packet = self.read_packet()?;
 
-        auth_result?;
-        // If authentication was successful, we have evertything to validate the certificate.
-        self.validate_mariadb_certificate_if_needed()
+            // check for auth-switch
+            if packet[0] == 0xFE && !auth_switched {
+                let auth_switch = if packet.len() > 1 {
+                    ParseBuf(&packet).parse(())?
+                } else {
+                    let _ = ParseBuf(&packet).parse::<OldAuthSwitchRequest>(())?;
+                    // we'll map OldAuthSwitchRequest to an AuthSwitchRequest with mysql_old_password plugin.
+                    AuthSwitchRequest::new("mysql_old_password".as_bytes(), &*self.0.nonce)
+                        .into_owned()
+                };
+                return self.perform_auth_switch(auth_switch);
+            }
+
+            // check for escaping byte
+            let challenge = if packet[0] == 0x01 {
+                &packet[1..]
+            } else {
+                packet.as_ref()
+            };
+
+            match prev_response {
+                // plugin waits for another challenge
+                auth::plugins::Response::Next { .. } => {
+                    let response = auth_proc.run(&auth_ctx, challenge)?;
+                    if let Some(mut packet) = response.data() {
+                        self.write_packet(&mut packet)?;
+                    }
+                    prev_response = response;
+                }
+                // previous response was the last response for the plugin
+                // OK packet must follow
+                auth::plugins::Response::Last { .. } => {
+                    if packet[0] == 0x00 {
+                        self.handle_ok::<CommonOkPacket>(&packet)?;
+                        break;
+                    } else {
+                        return Err(DriverError(UnexpectedPacket));
+                    }
+                }
+            }
+        }
+
+        Ok(auth_proc)
     }
 
-    fn validate_mariadb_certificate_if_needed(&mut self) -> Result<()> {
+    fn validate_mariadb_certificate_if_needed(
+        &mut self,
+        auth_proc: auth::plugins::AuthProc,
+    ) -> Result<()> {
         let leaf_cert_fingerprint = match self.zero_config_leaf_cert_fingerprint() {
             Some(f) => f,
             // Nothing to validate, so we can return early.
             None => return Ok(()),
         };
 
+        let auth_context = self.auth_context()?;
         // Shared secret is stored in "info" field of OK packet that server sends after successful authentication. It's
         // prepended with 0x01 byte and in hex string form. If we did not get it, we cannot validate certificate.
         let shared_secret = self
@@ -1026,21 +1064,15 @@ impl Conn {
             .strip_prefix(&[1_u8])
             .ok_or(DriverError(CertificateCannotBeValidated))?;
 
-        let password_hash = self
-            .0
-            .auth_plugin
-            .hash_password(self.0.opts.get_pass())
+        let password_hash = auth_proc
+            .password_hash(&auth_context)
             .ok_or(DriverError(CertificateCannotBeValidated))?;
         // Initially the scrable is stored in nonce field. If we had to perform authentication switch during handshake,
         // we moved it to scramble field. So, if it's definde - we use scramble and nonce otherwise.
         if !crypto::verify_mariadb_shared_secret(
             shared_secret,
             &password_hash,
-            if let Some(scramble) = &self.0.scramble {
-                scramble
-            } else {
-                &self.0.nonce
-            },
+            &self.0.nonce,
             &leaf_cert_fingerprint,
         ) {
             self.0.zero_config_check = None;
@@ -1049,121 +1081,6 @@ impl Conn {
 
         self.0.zero_config_check = None;
         Ok(())
-    }
-
-    fn continue_mysql_native_password_auth(&mut self, auth_switched: bool) -> Result<()> {
-        let payload = self.read_packet()?;
-
-        match payload[0] {
-            // auth ok
-            0x00 => self.handle_ok::<CommonOkPacket>(&payload).map(drop),
-            // auth switch
-            0xfe if !auth_switched => {
-                let auth_switch = if payload.len() > 1 {
-                    ParseBuf(&payload).parse(())?
-                } else {
-                    let _ = ParseBuf(&payload).parse::<OldAuthSwitchRequest>(())?;
-                    // we'll map OldAuthSwitchRequest to an AuthSwitchRequest with mysql_old_password plugin.
-                    AuthSwitchRequest::new("mysql_old_password".as_bytes(), &*self.0.nonce)
-                        .into_owned()
-                };
-                self.perform_auth_switch(auth_switch)
-            }
-            _ => Err(DriverError(UnexpectedPacket)),
-        }
-    }
-
-    fn continue_caching_sha2_password_auth(&mut self, auth_switched: bool) -> Result<()> {
-        let payload = self.read_packet()?;
-
-        match payload[0] {
-            0x00 => {
-                // ok packet for empty password
-                Ok(())
-            }
-            0x01 => match payload[1] {
-                0x03 => {
-                    let payload = self.read_packet()?;
-                    self.handle_ok::<CommonOkPacket>(&payload).map(drop)
-                }
-                0x04 => {
-                    if !self.is_insecure() || self.is_socket() {
-                        let mut pass = self.0.opts.get_pass().map(Vec::from).unwrap_or_default();
-                        pass.push(0);
-                        self.write_packet(&mut pass.as_slice())?;
-                    } else {
-                        self.write_packet(&mut &[0x02][..])?;
-                        let payload = self.read_packet()?;
-                        let key = &payload[1..];
-                        let mut pass = self.0.opts.get_pass().map(Vec::from).unwrap_or_default();
-                        pass.push(0);
-                        for (i, c) in pass.iter_mut().enumerate() {
-                            *(c) ^= self.0.nonce[i % self.0.nonce.len()];
-                        }
-                        let encrypted_pass = crypto::encrypt(&pass, key);
-                        self.write_packet(&mut encrypted_pass.as_slice())?;
-                    }
-
-                    let payload = self.read_packet()?;
-                    self.handle_ok::<CommonOkPacket>(&payload).map(drop)
-                }
-                _ => Err(DriverError(UnexpectedPacket)),
-            },
-            0xfe if !auth_switched => {
-                let auth_switch_request = ParseBuf(&payload).parse(())?;
-                self.perform_auth_switch(auth_switch_request)
-            }
-            _ => Err(DriverError(UnexpectedPacket)),
-        }
-    }
-
-    fn continue_ed25519_auth(&mut self, auth_switched: bool) -> Result<()> {
-        let payload = self.read_packet()?;
-        match payload[0] {
-            // ok packet for empty password
-            0x00 => self.handle_ok::<CommonOkPacket>(&payload).map(drop),
-            0xfe if !auth_switched => {
-                let auth_switch_request = ParseBuf(&payload).parse(())?;
-                self.perform_auth_switch(auth_switch_request)
-            }
-            _ => Err(DriverError(UnexpectedPacket)),
-        }
-    }
-
-    fn continue_parsec_auth(&mut self, auth_switched: bool) -> Result<()> {
-        let packet = self.read_packet()?;
-        // Normally we need to skip escaping 0x01 byte. But in first parsec implementations, server did not send it.
-        let mut payload = &packet[0..];
-        if !packet.is_empty() && packet[0] == 0x01 {
-            payload = &packet[1..];
-        }
-        // At this point in future, when it will be possible for parsec to be default authentication method,
-        // we can have authentication switch request. The other possible option here(and for now the only option) -
-        // ext-salt packet.
-        if !payload.is_empty() && payload[0] == 0xfe && !auth_switched {
-            let auth_switch_request = ParseBuf(payload).parse(())?;
-            self.perform_auth_switch(auth_switch_request)
-        } else {
-            // Letting parser function decide if all is fine with the packet
-            self.0
-                .auth_plugin
-                .read_add_data(payload)
-                .ok_or(DriverError(crate::DriverError::InvalidParsecSalt))?;
-            // Now generating response.
-            let plugin_data = self
-                .0
-                .auth_plugin
-                .gen_data(self.0.opts.get_pass(), &self.0.nonce)
-                .unwrap();
-
-            self.write_struct(&plugin_data.into_owned())?;
-            // After client response, server will send either ok or error.
-            let payload = self.read_packet()?;
-            match payload[0] {
-                0x00 => self.handle_ok::<CommonOkPacket>(&payload).map(drop),
-                _ => Err(DriverError(UnexpectedPacket)),
-            }
-        }
     }
 
     fn reset_seq_id(&mut self) {
@@ -1608,6 +1525,36 @@ impl Queryable for Conn {
     }
 }
 
+struct AuthContext {
+    pass: Vec<u8>,
+    is_ipc_transport: bool,
+    is_tls_transport: bool,
+    scramble: Vec<u8>,
+    server_key_pem: Option<Vec<u8>>,
+}
+
+impl auth::plugins::Context for &'_ AuthContext {
+    fn pass(&self) -> &[u8] {
+        &self.pass
+    }
+
+    fn is_tls_transport(&self) -> bool {
+        self.is_tls_transport
+    }
+
+    fn is_ipc_transport(&self) -> bool {
+        self.is_ipc_transport
+    }
+
+    fn scramble(&self) -> &[u8] {
+        &self.scramble
+    }
+
+    fn server_key_pem(&self) -> Option<&[u8]> {
+        self.server_key_pem.as_deref()
+    }
+}
+
 impl Drop for Conn {
     fn drop(&mut self) {
         let stmt_cache = mem::replace(&mut self.0.stmt_cache, StmtCache::new(0));
@@ -1642,8 +1589,6 @@ mod test {
             params::{MissingNamedParameterError, ParamsConfusionError, ParamsError},
         };
         use rand::Rng;
-        #[cfg(feature = "time")]
-        use time::PrimitiveDateTime;
 
         use crate::{
             conn::ConnInner,
@@ -1691,7 +1636,7 @@ mod test {
             }
 
             if crate::test_misc::test_ssl() {
-                assert!(!conn.is_insecure());
+                assert!(conn.is_tls_connection());
             }
         }
 
@@ -2159,9 +2104,10 @@ mod test {
             type CreateUserFn = fn(bool, (u16, u16, u16), &str) -> Vec<String>;
 
             #[allow(clippy::type_complexity)]
-            const TEST_MATRIX: [(&str, ShouldRunFn, CreateUserFn); 5] = [
+            const TEST_MATRIX: [(&str, bool, ShouldRunFn, CreateUserFn); 12] = [
                 (
                     "mysql_old_password",
+                    true,
                     |is_mariadb, version| is_mariadb || version < (5, 7, 0),
                     |is_mariadb, version, pass| {
                         if is_mariadb {
@@ -2187,7 +2133,35 @@ mod test {
                     },
                 ),
                 (
+                    "mysql_old_password empty-pass",
+                    false,
+                    |is_mariadb, version| is_mariadb || version < (5, 7, 0),
+                    |is_mariadb, version, _pass| {
+                        if is_mariadb {
+                            vec![
+                                "CREATE USER '__mats'@'%' IDENTIFIED WITH mysql_old_password"
+                                    .into(),
+                                "SET old_passwords=1".into(),
+                                format!("ALTER USER '__mats'@'%' IDENTIFIED BY ''"),
+                                "SET old_passwords=0".into(),
+                            ]
+                        } else if matches!(version, (5, 6, _)) {
+                            vec![
+                                "CREATE USER '__mats'@'%' IDENTIFIED WITH mysql_old_password"
+                                    .into(),
+                                format!("SET PASSWORD FOR '__mats'@'%' = OLD_PASSWORD('')"),
+                            ]
+                        } else {
+                            vec![
+                                "CREATE USER '__mats'@'%'".into(),
+                                format!("SET PASSWORD FOR '__mats'@'%' = PASSWORD('')"),
+                            ]
+                        }
+                    },
+                ),
+                (
                     "mysql_native_password",
+                    true,
                     |is_mariadb, version| is_mariadb || version < (8, 4, 0),
                     |is_mariadb, version, pass| {
                         if is_mariadb {
@@ -2209,7 +2183,31 @@ mod test {
                     },
                 ),
                 (
+                    "mysql_native_password empty-pass",
+                    false,
+                    |is_mariadb, version| is_mariadb || version < (8, 4, 0),
+                    |is_mariadb, version, _pass| {
+                        if is_mariadb {
+                            vec![
+                                format!("CREATE USER '__mats'@'%' IDENTIFIED WITH mysql_native_password AS PASSWORD('')")
+                            ]
+                        } else if version < (8, 0, 0) {
+                            vec![
+                                "CREATE USER '__mats'@'%' IDENTIFIED WITH mysql_native_password"
+                                    .into(),
+                                "SET old_passwords = 0".into(),
+                                format!("SET PASSWORD FOR '__mats'@'%' = PASSWORD('')"),
+                            ]
+                        } else {
+                            vec![
+                                format!("CREATE USER '__mats'@'%' IDENTIFIED WITH mysql_native_password BY ''")
+                            ]
+                        }
+                    },
+                ),
+                (
                     "caching_sha2_password",
+                    true,
                     |is_mariadb, version| !is_mariadb && version >= (5, 8, 0),
                     |_is_mariadb, _version, pass| {
                         vec![
@@ -2218,7 +2216,38 @@ mod test {
                     },
                 ),
                 (
+                    "caching_sha2_password empty-pass",
+                    false,
+                    |is_mariadb, version| !is_mariadb && version >= (5, 8, 0),
+                    |_is_mariadb, _version, _pass| {
+                        vec![format!(
+                            "CREATE USER '__mats'@'%' IDENTIFIED WITH caching_sha2_password BY ''"
+                        )]
+                    },
+                ),
+                (
+                    "sha256_password",
+                    true,
+                    |is_mariadb, version| !is_mariadb && version >= (5, 8, 0),
+                    |_is_mariadb, _version, pass| {
+                        vec![format!(
+                            "CREATE USER '__mats'@'%' IDENTIFIED WITH sha256_password BY '{pass}'"
+                        )]
+                    },
+                ),
+                (
+                    "sha256_password empty-pass",
+                    false,
+                    |is_mariadb, version| !is_mariadb && version >= (5, 8, 0),
+                    |_is_mariadb, _version, _pass| {
+                        vec![format!(
+                            "CREATE USER '__mats'@'%' IDENTIFIED WITH sha256_password BY ''"
+                        )]
+                    },
+                ),
+                (
                     "client_ed25519",
+                    true,
                     |is_mariadb, version| is_mariadb && version >= (10, 4, 0),
                     |_is_mariadb, _version, pass| {
                         vec![
@@ -2227,11 +2256,32 @@ mod test {
                     },
                 ),
                 (
+                    "client_ed25519 empty-pass",
+                    false,
+                    |is_mariadb, version| is_mariadb && version >= (10, 4, 0),
+                    |_is_mariadb, _version, _pass| {
+                        vec![format!(
+                            "CREATE USER '__mats'@'%' IDENTIFIED WITH ed25519 AS PASSWORD('')"
+                        )]
+                    },
+                ),
+                (
                     "parsec",
+                    true,
                     |is_mariadb, version| is_mariadb && version >= (11, 6, 0),
                     |_is_mariadb, _version, pass| {
                         vec![format!(
                             "CREATE USER '__mats'@'%' IDENTIFIED WITH parsec AS PASSWORD('{pass}')"
+                        )]
+                    },
+                ),
+                (
+                    "parsec empty-pass",
+                    false,
+                    |is_mariadb, version| is_mariadb && version >= (11, 6, 0),
+                    |_is_mariadb, _version, _pass| {
+                        vec![format!(
+                            "CREATE USER '__mats'@'%' IDENTIFIED WITH parsec AS PASSWORD('')"
                         )]
                     },
                 ),
@@ -2263,7 +2313,7 @@ mod test {
                 Value::NULL
             );
 
-            for (plugin, should_run, create_statements) in TEST_MATRIX {
+            for (plugin, use_password, should_run, create_statements) in TEST_MATRIX {
                 dbg!(plugin);
                 let is_mariadb = conn.0.mariadb_server_version.is_some();
                 let version = conn.server_version();
@@ -2281,13 +2331,32 @@ mod test {
                         conn.query_drop(dbg!(statement)).unwrap();
                     }
 
+                    let mut conn3 = Conn::new(
+                        get_opts()
+                            .secure_auth(false)
+                            .user(Some("__mats"))
+                            .pass(use_password.then_some(pass.clone()))
+                            .db_name(None::<String>)
+                            .max_allowed_packet(Some(1024 * 1024 * 4))
+                            .prefer_socket(false)
+                            .init(Vec::<String>::new()),
+                    )
+                    .unwrap();
+
+                    let (db, user) = conn3
+                        .query_first::<(Option<String>, String), _>("SELECT DATABASE(), USER();")
+                        .unwrap()
+                        .unwrap();
+                    assert_eq!(db, None);
+                    assert!(user.starts_with("__mats"));
+
                     let mut conn2 = Conn::new(get_opts().secure_auth(false)).unwrap();
                     conn2
                         .change_user(
                             crate::ChangeUserOpts::default()
                                 .with_db_name(None)
                                 .with_user(Some("__mats".into()))
-                                .with_pass(Some(pass)),
+                                .with_pass(use_password.then_some(pass)),
                         )
                         .unwrap();
 
@@ -2323,54 +2392,52 @@ mod test {
 
         #[test]
         fn should_connect_via_socket_for_127_0_0_1() {
-            let opts = OptsBuilder::from_opts(get_opts());
+            let opts = OptsBuilder::from_opts(get_opts().prefer_socket(true));
             let mut conn = Conn::new(opts).unwrap();
-            if conn.is_insecure() {
-                assert!(
-                    conn.is_socket(),
-                    "Did not reconnect via socket {:?}",
-                    (
-                        conn.0.opts.get_prefer_socket(),
-                        conn.0.opts.addr_is_loopback(),
-                        conn.can_improved().and_then(|opts| {
-                            opts.map(|opts| {
-                                let mut new = crate::conn::Conn(Box::new(ConnInner::empty(opts)));
-                                new.connect_stream().and_then(|_| {
-                                    new.connect()?;
-                                    Ok(new)
-                                })
+            assert!(
+                conn.is_socket_connection(),
+                "Did not reconnect via socket {:?}",
+                (
+                    conn.0.opts.get_prefer_socket(),
+                    conn.0.opts.addr_is_loopback(),
+                    conn.can_improved().and_then(|opts| {
+                        opts.map(|opts| {
+                            let mut new = crate::conn::Conn(Box::new(ConnInner::empty(opts)));
+                            new.connect_stream().and_then(|_| {
+                                new.connect()?;
+                                Ok(new)
                             })
-                            .transpose()
-                        }),
-                    )
-                );
-            }
+                        })
+                        .transpose()
+                    }),
+                )
+            );
         }
 
         #[test]
         fn should_connect_via_socket_localhost() {
-            let opts = OptsBuilder::from_opts(get_opts()).ip_or_hostname(Some("localhost"));
+            let opts = get_opts()
+                .prefer_socket(true)
+                .ip_or_hostname(Some("localhost"));
             let mut conn = Conn::new(opts).unwrap();
-            if conn.is_insecure() {
-                assert!(
-                    conn.is_socket(),
-                    "Did not reconnect via socket {:?}",
-                    (
-                        conn.0.opts.get_prefer_socket(),
-                        conn.0.opts.addr_is_loopback(),
-                        conn.can_improved().and_then(|opts| {
-                            opts.map(|opts| {
-                                let mut new = crate::conn::Conn(Box::new(ConnInner::empty(opts)));
-                                new.connect_stream().and_then(|_| {
-                                    new.connect()?;
-                                    Ok(new)
-                                })
+            assert!(
+                conn.is_socket_connection(),
+                "Did not reconnect via socket {:?}",
+                (
+                    conn.0.opts.get_prefer_socket(),
+                    conn.0.opts.addr_is_loopback(),
+                    conn.can_improved().and_then(|opts| {
+                        opts.map(|opts| {
+                            let mut new = crate::conn::Conn(Box::new(ConnInner::empty(opts)));
+                            new.connect_stream().and_then(|_| {
+                                new.connect()?;
+                                Ok(new)
                             })
-                            .transpose()
-                        }),
-                    )
-                );
-            }
+                        })
+                        .transpose()
+                    }),
+                )
+            );
         }
 
         /// QueryResult::drop hangs on connectivity errors (see [blackbeam/rust-mysql-simple#306][1]).
@@ -3075,9 +3142,21 @@ mod test {
             conn.exec_batch(query, params)
                 .expect("Batch execution should succeed");
 
-            let inserted_rows: Vec<(u64, String)> = conn
-                .query("SELECT id, val FROM t_large_batch ORDER BY id") // Order by data to get a predictable "a", "b", "c" order
-                .unwrap();
+            // MySql compression does not respect max_allowed_packet, so we're going to query
+            // one by one
+            let mut inserted_rows: Vec<(u64, String)> = vec![];
+            inserted_rows.extend(
+                conn.query("SELECT id, val FROM t_large_batch ORDER BY id LIMIT 1 OFFSET 0")
+                    .unwrap(),
+            );
+            inserted_rows.extend(
+                conn.query("SELECT id, val FROM t_large_batch ORDER BY id LIMIT 1 OFFSET 1")
+                    .unwrap(),
+            );
+            inserted_rows.extend(
+                conn.query("SELECT id, val FROM t_large_batch ORDER BY id LIMIT 65536 OFFSET 2")
+                    .unwrap(),
+            );
 
             assert_eq!(
                 inserted_rows.len(),
@@ -3118,7 +3197,6 @@ mod test {
             Ok(())
         }
 
-        #[cfg_attr(docsrs, doc(cfg(feature = "client_parsec")))]
         #[test]
         #[cfg(feature = "client_parsec")]
         fn parsec_connect() {
@@ -3178,7 +3256,7 @@ mod test {
                     ))
                     .unwrap();
 
-                assert!(!conn.is_insecure());
+                assert!(conn.is_tls_connection());
                 assert!(conn.ping().is_ok());
             }
             Ok(())
@@ -3229,7 +3307,7 @@ mod test {
                             crate::SslOpts::default().with_danger_skip_domain_validation(false),
                         ),
                 )?;
-                assert!(!conn.is_insecure());
+                assert!(conn.is_tls_connection());
                 assert!(conn.ping().is_ok());
 
                 // Testing that we can't make secure connection with empty password.
@@ -3299,7 +3377,7 @@ mod test {
                             crate::SslOpts::default().with_danger_skip_domain_validation(false),
                         ),
                 )?;
-                assert!(!conn.is_insecure());
+                assert!(conn.is_tls_connection());
                 assert!(conn.ping().is_ok());
                 drop(conn);
                 aux.query_drop("DROP USER 'parsec_tls_test_user'@'%'")?;

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -11,7 +11,7 @@ use bytes::{Buf, BufMut};
 use mysql_common::packets::binlog_request::BinlogRequest;
 use mysql_common::{
     constants::UTF8MB4_GENERAL_CI,
-    crypto,
+    crypto::{self, MariaDbZeroConfigCheck},
     io::{ParseBuf, ReadMysqlExt},
     named_params::ParsedNamedParams,
     packets::{
@@ -37,7 +37,7 @@ use std::{
     mem,
     ops::{Deref, DerefMut},
     process,
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 #[cfg(unix)]
@@ -59,9 +59,9 @@ use crate::{
     prelude::*,
     ChangeUserOpts,
     DriverError::{
-        CleartextPluginDisabled, MismatchedStmtParams, OldMysqlPasswordDisabled, Protocol41NotSet,
-        ReadOnlyTransNotSupported, SetupError, UnexpectedPacket, UnknownAuthPlugin,
-        UnsupportedProtocol,
+        CertificateCannotBeValidated, CleartextPluginDisabled, MismatchedStmtParams,
+        OldMysqlPasswordDisabled, Protocol41NotSet, ReadOnlyTransNotSupported, SetupError,
+        UnexpectedPacket, UnknownAuthPlugin, UnsupportedProtocol,
     },
     Error::{self, DriverError, MySqlError},
     LocalInfileHandler, Opts, OptsBuilder, Params, QueryResult, Result, Transaction,
@@ -198,7 +198,6 @@ impl ResultSetInfo {
 }
 
 /// Connection internals.
-#[derive(Debug)]
 struct ConnInner {
     opts: Opts,
     stream: Option<MySyncFramed<Stream>>,
@@ -222,9 +221,41 @@ struct ConnInner {
 
     auth_plugin: AuthPlugin<'static>,
     nonce: Vec<u8>,
+    // To preserve scramble if it gets overwritten during auth switch, as it's needed for MariaDB "zero-config TLS" fallback validation.
+    scramble: Option<[u8; 20]>,
+    zero_config_check: Option<Arc<Mutex<Option<MariaDbZeroConfigCheck>>>>,
 
     /// This flag is to opt-in/opt-out from reset upon return to a pool.
     pub(crate) reset_upon_return: bool,
+}
+
+impl std::fmt::Debug for ConnInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConnInner")
+            .field("opts", &self.opts)
+            .field("stream", &self.stream)
+            .field("stmt_cache", &self.stmt_cache)
+            .field("server_version", &self.server_version)
+            .field("mariadb_server_version", &self.mariadb_server_version)
+            .field("ok_packet", &self.ok_packet)
+            .field("capability_flags", &self.capability_flags)
+            .field("mariadb_ext_capabilities", &self.mariadb_ext_capabilities)
+            .field("connection_id", &self.connection_id)
+            .field("status_flags", &self.status_flags)
+            .field("character_set", &self.character_set)
+            .field("last_command", &self.last_command)
+            .field("connected", &self.connected)
+            .field("has_results", &self.has_results)
+            .field("local_infile_handler", &self.local_infile_handler)
+            .field("auth_plugin", &self.auth_plugin)
+            .field("nonce", &self.nonce)
+            .field(
+                "zero_config_check",
+                &self.zero_config_check.as_ref().map(|_| "<hidden>"),
+            )
+            .field("reset_upon_return", &self.reset_upon_return)
+            .finish()
+    }
 }
 
 impl ConnInner {
@@ -246,6 +277,8 @@ impl ConnInner {
             local_infile_handler: None,
             auth_plugin: AuthPlugin::MysqlNativePassword,
             nonce: Vec::new(),
+            scramble: None,
+            zero_config_check: None,
             reset_upon_return: opts.get_pool_opts().reset_connection(),
 
             opts,
@@ -258,6 +291,36 @@ impl ConnInner {
 pub struct Conn(Box<ConnInner>);
 
 impl Conn {
+    // Returns true if MariaDB zero-config fallback is currently pending (i.e., certificate validation is required).
+    fn zero_config_fallback_pending(&self) -> bool {
+        self.0
+            .zero_config_check
+            .as_ref()
+            .and_then(|zcc| zcc.lock().ok())
+            .and_then(|guard| {
+                guard
+                    .as_ref()
+                    .map(|check| check.requires_zeroconfig_fallback())
+            })
+            .unwrap_or(false)
+    }
+
+    // Returns the leaf certificate fingerprint if zero-config fallback is pending, or None otherwise.
+    fn zero_config_leaf_cert_fingerprint(&self) -> Option<Vec<u8>> {
+        self.0
+            .zero_config_check
+            .as_ref()
+            .and_then(|zcc| zcc.lock().ok())
+            .and_then(|guard| {
+                guard.as_ref().and_then(|check| {
+                    if check.requires_zeroconfig_fallback() {
+                        Some(check.leaf_cert_fingerprint().to_vec())
+                    } else {
+                        None
+                    }
+                })
+            })
+    }
     /// Must not be called before handle_handshake.
     const fn has_capability(&self, flag: CapabilityFlags) -> bool {
         self.0.capability_flags.contains(flag)
@@ -507,10 +570,26 @@ impl Conn {
         self.exec_com_change_user(opts)
     }
 
+    // Returns true if MariaDB fallback should be enabled for this connection.
+    fn mariadb_fallback_possible(&self) -> bool {
+        self.0
+            .mariadb_server_version
+            .map_or(false, |ver| ver > (11, 4, 0))
+            && self.0.opts.get_pass().map_or(false, |p| !p.is_empty())
+            && self.0.auth_plugin.supports_password_hash()
+    }
+
     fn switch_to_ssl(&mut self, ssl_opts: SslOpts) -> Result<()> {
         let stream = self.0.stream.take().expect("incomplete conn");
         let (in_buf, out_buf, codec, stream) = stream.destruct();
-        let stream = stream.make_secure(self.0.opts.get_host(), ssl_opts)?;
+        self.0.zero_config_check = self
+            .mariadb_fallback_possible()
+            .then(|| Arc::new(Mutex::new(None)));
+        let stream = stream.make_secure(
+            self.0.opts.get_host(),
+            ssl_opts,
+            self.0.zero_config_check.clone(),
+        )?;
         let stream = MySyncFramed::construct(in_buf, out_buf, codec, stream);
         self.0.stream = Some(stream);
         Ok(())
@@ -669,22 +748,34 @@ impl Conn {
             return Err(DriverError(CleartextPluginDisabled));
         }
 
+        if self.zero_config_fallback_pending() {
+            if !auth_switch_request.auth_plugin().supports_password_hash() {
+                self.0.zero_config_check = None;
+                return Err(DriverError(CertificateCannotBeValidated));
+            } else {
+                // Storing scramble as it's used in "zero-config ssl" certificate validation.
+                if let Ok(scramble_arr) = self.0.nonce[..].try_into() {
+                    self.0.scramble = Some(scramble_arr);
+                }
+            }
+        }
+
         self.0.nonce = auth_switch_request.plugin_data().to_vec();
         self.0.auth_plugin = auth_switch_request.auth_plugin().into_owned();
         let plugin_data = match self.0.auth_plugin {
-            ref x @ AuthPlugin::MysqlOldPassword => {
+            ref mut x @ AuthPlugin::MysqlOldPassword => {
                 if self.0.opts.get_secure_auth() {
                     return Err(DriverError(OldMysqlPasswordDisabled));
                 }
                 x.gen_data(self.0.opts.get_pass(), &self.0.nonce)
             }
-            ref x @ AuthPlugin::MysqlNativePassword => {
+            ref mut x @ AuthPlugin::MysqlNativePassword => {
                 x.gen_data(self.0.opts.get_pass(), &self.0.nonce)
             }
-            ref x @ AuthPlugin::CachingSha2Password => {
+            ref mut x @ AuthPlugin::CachingSha2Password => {
                 x.gen_data(self.0.opts.get_pass(), &self.0.nonce)
             }
-            ref x @ AuthPlugin::MysqlClearPassword => {
+            ref mut x @ AuthPlugin::MysqlClearPassword => {
                 if !self.0.opts.get_enable_cleartext_plugin() {
                     return Err(DriverError(UnknownAuthPlugin(
                         "mysql_clear_password".into(),
@@ -693,7 +784,7 @@ impl Conn {
 
                 x.gen_data(self.0.opts.get_pass(), &self.0.nonce)
             }
-            ref x @ AuthPlugin::Ed25519 => x.gen_data(self.0.opts.get_pass(), &self.0.nonce),
+            ref mut x @ AuthPlugin::Ed25519 => x.gen_data(self.0.opts.get_pass(), &self.0.nonce),
             // For parsec at this point we need to send an empty packet first
             ref _x @ AuthPlugin::MariadbParsec { .. } => None,
             AuthPlugin::Other(_) => None,
@@ -882,7 +973,7 @@ impl Conn {
     }
 
     fn continue_auth(&mut self, auth_switched: bool) -> Result<()> {
-        match self.0.auth_plugin {
+        let auth_result = match self.0.auth_plugin {
             AuthPlugin::CachingSha2Password => {
                 self.continue_caching_sha2_password_auth(auth_switched)?;
                 Ok(())
@@ -910,7 +1001,48 @@ impl Conn {
                 let plugin_name = String::from_utf8_lossy(name).into();
                 Err(DriverError(UnknownAuthPlugin(plugin_name)))
             }
+        };
+
+        auth_result?;
+        self.validate_mariadb_certificate_if_needed()
+    }
+
+    fn validate_mariadb_certificate_if_needed(&mut self) -> Result<()> {
+        let leaf_cert_fingerprint = match self.zero_config_leaf_cert_fingerprint() {
+            Some(f) => f,
+            None => return Ok(()),
+        };
+
+        // Shared secret is stored in "info" field of OK packet that server sends after successful authentication. It's
+        // prepended with 0x01 byte and in hex string form. If we did not get it, we cannot validate certificate.
+        let shared_secret = self
+            .info_ref()
+            .strip_prefix(&[1_u8])
+            .ok_or(DriverError(CertificateCannotBeValidated))?;
+
+        let password_hash = self
+            .0
+            .auth_plugin
+            .hash_password(self.0.opts.get_pass())
+            .ok_or(DriverError(CertificateCannotBeValidated))?;
+        // Initially the scrable is stored in nonce field. If we had to perform authentication switch during handshake,
+        // we moved it to scramble field. So, if it's definde - we use scramble and nonce otherwise.
+        if !crypto::verify_mariadb_shared_secret(
+            shared_secret,
+            &password_hash,
+            if let Some(scramble) = &self.0.scramble {
+                scramble
+            } else {
+                &self.0.nonce
+            },
+            &leaf_cert_fingerprint,
+        ) {
+            self.0.zero_config_check = None;
+            return Err(DriverError(CertificateCannotBeValidated));
         }
+
+        self.0.zero_config_check = None;
+        Ok(())
     }
 
     fn continue_mysql_native_password_auth(&mut self, auth_switched: bool) -> Result<()> {
@@ -983,7 +1115,7 @@ impl Conn {
         let payload = self.read_packet()?;
         match payload[0] {
             // ok packet for empty password
-            0x00 => Ok(()),
+            0x00 => self.handle_ok::<CommonOkPacket>(&payload).map(drop),
             0xfe if !auth_switched => {
                 let auth_switch_request = ParseBuf(&payload).parse(())?;
                 self.perform_auth_switch(auth_switch_request)
@@ -1526,6 +1658,15 @@ mod test {
                 .unwrap()
                 .unwrap()
                 .1
+        }
+
+        fn random_pass() -> String {
+            let mut rng = rand::rng();
+            let mut pass = [0u8; 10];
+            rng.fill_bytes(&mut pass);
+            IntoIterator::into_iter(pass)
+                .map(|x| ((x % (123 - 97)) + 97) as char)
+                .collect()
         }
 
         #[test]
@@ -2089,15 +2230,6 @@ mod test {
                     },
                 ),
             ];
-
-            fn random_pass() -> String {
-                let mut rng = rand::rng();
-                let mut pass = [0u8; 10];
-                rng.fill_bytes(&mut pass);
-                IntoIterator::into_iter(pass)
-                    .map(|x| ((x % (123 - 97)) + 97) as char)
-                    .collect()
-            }
 
             let mut conn = Conn::new(get_opts()).unwrap();
 
@@ -2984,23 +3116,13 @@ mod test {
         #[test]
         #[cfg(feature = "client_parsec")]
         fn parsec_connect() {
-            let mut conn = Conn::new(get_opts()).unwrap();
+            let mut conn = Conn::new(get_opts().ssl_opts(None)).unwrap();
             let is_mariadb = conn.0.mariadb_server_version.is_some();
             let version = conn.server_version();
             if is_mariadb && version >= (11, 6, 0) {
                 // Creating random password so in case of test failure user won't have
                 // known password left behind.
-                let mut rng = rand::rng();
-                let mut pass_bytes = [0u8; 16];
-                rng.fill_bytes(&mut pass_bytes);
-                pass_bytes.iter_mut().for_each(|b| {
-                    *b = match *b % 3 {
-                        0 => b'A' + (*b % 26),
-                        1 => b'a' + (*b % 26),
-                        _ => b'0' + (*b % 10),
-                    }
-                });
-                let pass = String::from_utf8_lossy(&pass_bytes).to_string();
+                let pass = random_pass();
 
                 conn.query_drop("DROP USER IF EXISTS 'parsec_test_user'@'%'")
                     .unwrap();
@@ -3020,6 +3142,186 @@ mod test {
                 assert!(conn_parsec.ping().is_ok());
                 conn.query_drop("DROP USER 'parsec_test_user'@'%'").unwrap();
             }
+        }
+
+        #[cfg_attr(
+            docsrs,
+            doc(cfg(any(
+                feature = "rustls",
+                feature = "rustls-tls",
+                feature = "rustls-tls-ring"
+            )))
+        )]
+        #[test]
+        #[cfg(any(
+            feature = "rustls",
+            feature = "rustls-tls",
+            feature = "rustls-tls-ring"
+        ))]
+        fn mariadb_auto_tls() -> crate::Result<()> {
+            let aux = Conn::new(get_opts().ssl_opts(None)).unwrap();
+            let is_mariadb = aux.0.mariadb_server_version.is_some();
+            let version = aux.server_version();
+            if is_mariadb && version > (11, 4, 0) {
+                let mut conn =
+                    Conn::new(get_opts().ssl_opts(
+                        crate::SslOpts::default().with_danger_skip_domain_validation(false),
+                    ))
+                    .unwrap();
+
+                assert!(!conn.is_insecure());
+                assert!(conn.ping().is_ok());
+            }
+            Ok(())
+        }
+
+        #[cfg_attr(
+            docsrs,
+            doc(cfg(all(
+                any(
+                    feature = "rustls",
+                    feature = "rustls-tls",
+                    feature = "rustls-tls-ring"
+                ),
+                feature = "client_ed25519"
+            )))
+        )]
+        #[test]
+        #[cfg(all(
+            any(
+                feature = "rustls",
+                feature = "rustls-tls",
+                feature = "rustls-tls-ring"
+            ),
+            feature = "client_ed25519"
+        ))]
+        fn mariadb_auto_tls_ed25519() -> crate::Result<()> {
+            let mut aux = Conn::new(get_opts().ssl_opts(None)).unwrap();
+            let is_mariadb = aux.0.mariadb_server_version.is_some();
+            let version = aux.server_version();
+            if is_mariadb && version > (11, 4, 0) {
+                let pass = random_pass();
+
+                aux.query_drop("DROP USER IF EXISTS 'ed25519_tls_test_user'@'%'")
+                    .unwrap();
+                let create_user_query = format!(
+                    "CREATE USER 'ed25519_tls_test_user'@'%' IDENTIFIED WITH ed25519 USING PASSWORD('{pass}')"
+                );
+                aux.query_drop(create_user_query).unwrap();
+
+                let mut conn = Conn::new(
+                    get_opts()
+                        .user(Some("ed25519_tls_test_user"))
+                        .pass(Some(pass))
+                        .db_name(None::<String>)
+                        .init(vec![] as Vec<String>)
+                        .ssl_opts(
+                            crate::SslOpts::default().with_danger_skip_domain_validation(false),
+                        ),
+                )?;
+                assert!(!conn.is_insecure());
+                assert!(conn.ping().is_ok());
+
+                // Testing that we can't make secure connection with empty password.
+                // "Zero config SSL" does not work with empty password.
+                // This can fail if server has real certificate.
+                conn.query_drop("SET PASSWORD = PASSWORD('')")?;
+                drop(conn);
+
+                let conn = Conn::new(
+                    get_opts()
+                        .user(Some("ed25519_tls_test_user"))
+                        .pass(Some(""))
+                        .db_name(None::<String>)
+                        .init(vec![] as Vec<String>)
+                        .ssl_opts(
+                            crate::SslOpts::default().with_danger_skip_domain_validation(false),
+                        ),
+                );
+                // We shouldn't have got secure connection with insesure plugins -
+                // connection should have failed.
+                assert!(conn.is_err());
+                aux.query_drop("DROP USER 'ed25519_tls_test_user'@'%'")?;
+            }
+            Ok(())
+        }
+
+        #[cfg_attr(
+            docsrs,
+            doc(cfg(all(
+                any(
+                    feature = "rustls",
+                    feature = "rustls-tls",
+                    feature = "rustls-tls-ring"
+                ),
+                feature = "client_parsec"
+            )))
+        )]
+        #[test]
+        #[cfg(all(
+            any(
+                feature = "rustls",
+                feature = "rustls-tls",
+                feature = "rustls-tls-ring"
+            ),
+            feature = "client_parsec"
+        ))]
+        fn mariadb_auto_tls_parsec() -> crate::Result<()> {
+            let mut aux = Conn::new(get_opts().ssl_opts(None)).unwrap();
+            let is_mariadb = aux.0.mariadb_server_version.is_some();
+            let version = aux.server_version();
+            if is_mariadb && version >= (11, 6, 0) {
+                let pass = random_pass();
+                aux.query_drop("DROP USER IF EXISTS 'parsec_tls_test_user'@'%'")?;
+                let create_user_query = format!(
+                   "CREATE USER 'parsec_tls_test_user'@'%' IDENTIFIED VIA 'parsec' USING PASSWORD('{pass}')"
+                );
+                aux.query_drop(create_user_query)?;
+
+                let mut conn = Conn::new(
+                    get_opts()
+                        .user(Some("parsec_tls_test_user"))
+                        .pass(Some(pass.clone()))
+                        .db_name(None::<String>)
+                        .init(vec![] as Vec<String>)
+                        .ssl_opts(
+                            crate::SslOpts::default().with_danger_skip_domain_validation(false),
+                        ),
+                )?;
+                assert!(!conn.is_insecure());
+                assert!(conn.ping().is_ok());
+                drop(conn);
+                aux.query_drop("DROP USER 'parsec_tls_test_user'@'%'")?;
+
+                // caching_sha2_password is not MitM-proof. "Zero config SSL" does not work with such authentication methods.
+                // This can fail if server has real certificate. Combining 2 tests to be sure for the 2nd test that "zero config SSL"
+                // works in general.
+                aux.query_drop("DROP USER IF EXISTS 'caching_sha2_tls_test_user'@'%'")?;
+                if aux
+                    .query_drop(
+                        "CREATE USER 'caching_sha2_tls_test_user'@'%'
+                IDENTIFIED WITH caching_sha2_password USING PASSWORD('{pass}')",
+                    )
+                    .is_ok()
+                {
+                    // Test makes sense only if the plugin is present and active. If we can't create user with such plugin, we can skip the test.
+                    let conn = Conn::new(
+                        get_opts()
+                            .user(Some("ed25519_tls_test_user"))
+                            .pass(Some(pass))
+                            .db_name(None::<String>)
+                            .init(vec![] as Vec<String>)
+                            .ssl_opts(
+                                crate::SslOpts::default().with_danger_skip_domain_validation(false),
+                            ),
+                    );
+                    // We shouldn't have had secure connection with insecure plugins -
+                    // connection should have failed.
+                    assert!(conn.is_err());
+                    aux.query_drop("DROP USER 'caching_sha2_tls_test_user'@'%'")?;
+                }
+            }
+            Ok(())
         }
 
         #[test]

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -533,6 +533,8 @@ impl Conn {
 
         let mut auth_proc = self.0.auth_plugin.init()?;
         let auth_ctx = self.auth_context()?;
+        #[cfg(test)]
+        eprintln!("{}:{} {auth_proc:?}\n{:?}", file!(), line!(), self.0.nonce);
         let response = auth_proc.run(&auth_ctx, &self.0.nonce)?;
 
         let com_change_user = ComChangeUser::new()
@@ -814,6 +816,13 @@ impl Conn {
 
         let auth_ctx = self.auth_context()?;
         let mut auth_proc = auth_switch_request.auth_plugin().init()?;
+        #[cfg(test)]
+        eprintln!(
+            "{}:{} {auth_proc:?}\n{:?}",
+            file!(),
+            line!(),
+            auth_switch_request.plugin_data()
+        );
         let response = auth_proc.run(&auth_ctx, auth_switch_request.plugin_data())?;
         if let Some(mut packet) = response.data() {
             self.write_packet(&mut packet)?;
@@ -864,6 +873,8 @@ impl Conn {
 
         let auth_ctx = self.auth_context()?;
         let mut auth_proc = self.0.auth_plugin.init()?;
+        #[cfg(test)]
+        eprintln!("{}:{} {auth_proc:?}\n{:?}", file!(), line!(), self.0.nonce);
         let response = auth_proc.run(&auth_ctx, &self.0.nonce)?;
 
         self.write_handshake_response(response.data())?;
@@ -1024,6 +1035,8 @@ impl Conn {
             match prev_response {
                 // plugin waits for another challenge
                 auth::plugins::Response::Next { .. } => {
+                    #[cfg(test)]
+                    eprintln!("{}:{} {auth_proc:?}\n{:?}", file!(), line!(), challenge);
                     let response = auth_proc.run(&auth_ctx, challenge)?;
                     if let Some(mut packet) = response.data() {
                         self.write_packet(&mut packet)?;

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -223,6 +223,8 @@ struct ConnInner {
     nonce: Vec<u8>,
     // To preserve scramble if it gets overwritten during auth switch, as it's needed for MariaDB "zero-config TLS" fallback validation.
     scramble: Option<[u8; 20]>,
+    // This is passed to TLS certificate verifier as a flag if zero-config validation is possible for this connection.
+    // If so, the verifier will store the info required to complete the validation and this will be also the flag that such validation is pending.
     zero_config_check: Option<Arc<Mutex<Option<MariaDbZeroConfigCheck>>>>,
 
     /// This flag is to opt-in/opt-out from reset upon return to a pool.
@@ -748,6 +750,8 @@ impl Conn {
             return Err(DriverError(CleartextPluginDisabled));
         }
 
+        // If zero-config fallback is pending but auth plugin is not right for it - returning certificate validation error.
+        // Otherwise, storing scramble for later use in certificate validation.
         if self.zero_config_fallback_pending() {
             if !auth_switch_request.auth_plugin().supports_password_hash() {
                 self.0.zero_config_check = None;
@@ -1004,12 +1008,14 @@ impl Conn {
         };
 
         auth_result?;
+        // If authentication was successful, we have evertything to validate the certificate.
         self.validate_mariadb_certificate_if_needed()
     }
 
     fn validate_mariadb_certificate_if_needed(&mut self) -> Result<()> {
         let leaf_cert_fingerprint = match self.zero_config_leaf_cert_fingerprint() {
             Some(f) => f,
+            // Nothing to validate, so we can return early.
             None => return Ok(()),
         };
 
@@ -3158,6 +3164,9 @@ mod test {
             feature = "rustls-tls",
             feature = "rustls-tls-ring"
         ))]
+        // Test of MariaDB "Zero config SSL" with native authentication - one of three supported by the feature.
+        // First making connection to verify that this is MariaDB server and that it supports "Zero config SSL"
+        // (MariaDB >= 11.4.0) then trying to establish TLS connection making sure that certificate is validated.
         fn mariadb_auto_tls() -> crate::Result<()> {
             let aux = Conn::new(get_opts().ssl_opts(None)).unwrap();
             let is_mariadb = aux.0.mariadb_server_version.is_some();
@@ -3195,6 +3204,7 @@ mod test {
             ),
             feature = "client_ed25519"
         ))]
+        // Test of MariaDB "Zero config SSL" with ed25519 authentication
         fn mariadb_auto_tls_ed25519() -> crate::Result<()> {
             let mut aux = Conn::new(get_opts().ssl_opts(None)).unwrap();
             let is_mariadb = aux.0.mariadb_server_version.is_some();
@@ -3266,6 +3276,7 @@ mod test {
             ),
             feature = "client_parsec"
         ))]
+        // Test of MariaDB "Zero config SSL" with parsec authentication
         fn mariadb_auto_tls_parsec() -> crate::Result<()> {
             let mut aux = Conn::new(get_opts().ssl_opts(None)).unwrap();
             let is_mariadb = aux.0.mariadb_server_version.is_some();

--- a/src/conn/opts/mod.rs
+++ b/src/conn/opts/mod.rs
@@ -10,7 +10,13 @@ use percent_encoding::percent_decode;
 use url::Url;
 
 use std::{
-    borrow::Cow, collections::HashMap, fmt, hash::Hash, net::SocketAddr, path::Path, time::Duration,
+    borrow::Cow,
+    collections::HashMap,
+    fmt,
+    hash::Hash,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    time::Duration,
 };
 
 use crate::{
@@ -248,6 +254,17 @@ pub(crate) struct InnerOpts {
     /// consider using TLS or encrypted tunnels for server connection.
     enable_cleartext_plugin: bool,
 
+    /// Returns server public key path (defaults to `None`).
+    ///
+    /// The path contains a client side copy of the server public key in PEM format.
+    ///
+    /// # Security Notes
+    ///
+    /// This is not a TLS option — this path is used only for caching_sha2_password plugin
+    /// to make it not vulnerable to MITM. If it is not given then the public key will be
+    /// requested from the server.
+    server_key_path: Option<PathBuf>,
+
     /// Client side `max_allowed_packet` value (defaults to `None`).
     ///
     /// By default `Conn` will query this value from the server. One can avoid this step
@@ -292,6 +309,7 @@ impl Default for InnerOpts {
             connect_attrs: Some(HashMap::new()),
             secure_auth: true,
             enable_cleartext_plugin: false,
+            server_key_path: None,
             #[cfg(test)]
             injected_socket: None,
         }
@@ -557,6 +575,19 @@ impl Opts {
     pub fn get_enable_cleartext_plugin(&self) -> bool {
         self.0.enable_cleartext_plugin
     }
+
+    /// Returns server public key path (defaults to `None`).
+    ///
+    /// The path contains a client side copy of the server public key in PEM format.
+    ///
+    /// # Security Notes
+    ///
+    /// This is not a TLS option — this path is used only for caching_sha2_password plugin
+    /// to make it not vulnerable to MITM. If it is not given then the public key will be
+    /// requested from the server.
+    pub fn get_server_key_path(&self) -> Option<&Path> {
+        self.0.server_key_path.as_deref()
+    }
 }
 
 /// Provides a way to build [`Opts`](struct.Opts.html).
@@ -677,6 +708,7 @@ impl OptsBuilder {
                         return Err(UrlError::InvalidValue(key.to_string(), value.to_string()))
                     }
                 },
+                "server_key_path" => self.opts.0.server_key_path = Some(PathBuf::from(value)),
                 "secure_auth" => match value.parse::<bool>() {
                     Ok(parsed) => self.opts.0.secure_auth = parsed,
                     Err(_) => {
@@ -1127,6 +1159,32 @@ impl OptsBuilder {
     /// ```
     pub fn enable_cleartext_plugin(mut self, enable_cleartext_plugin: bool) -> Self {
         self.opts.0.enable_cleartext_plugin = enable_cleartext_plugin;
+        self
+    }
+
+    /// Returns server public key path (defaults to `None`).
+    ///
+    /// The path contains a client side copy of the server public key in PEM format.
+    ///
+    /// # Security Notes
+    ///
+    /// This is not a TLS option — this path is used only for caching_sha2_password plugin
+    /// to make it not vulnerable to MITM. If it is not given then the public key will be
+    /// requested from the server.
+    ///
+    /// # Connection URL
+    ///
+    /// Use `enable_cleartext_plugin` URL parameter to set this value. E.g.
+    ///
+    /// ```
+    /// # use mysql::*;
+    /// # use std::path::Path;
+    /// # fn main() -> Result<()> {
+    /// let opts = Opts::from_url("mysql://localhost/db?server_key_path=/some/path/key.pem")?;
+    /// assert_eq!(opts.get_server_key_path(), Some(Path::new("/some/path/key.pem")));
+    /// # Ok(()) }
+    pub fn server_key_path(mut self, server_key_path: Option<PathBuf>) -> Self {
+        self.opts.0.server_key_path = server_key_path;
         self
     }
 }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -224,6 +224,7 @@ pub enum DriverError {
     CleartextPluginDisabled,
     BulkExecute(BulkExecuteRequestError),
     InvalidParsecSalt,
+    CertificateCannotBeValidated,
 }
 
 impl From<BulkExecuteRequestBuilderError> for DriverError {
@@ -311,6 +312,9 @@ impl fmt::Display for DriverError {
             }
             DriverError::InvalidParsecSalt => {
                 write!(f, "Could not parse Parsec extended salt packet")
+            }
+            DriverError::CertificateCannotBeValidated => {
+                write!(f, "Server certificate cannot be validated")
             }
         }
     }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -7,6 +7,7 @@
 // modified, or distributed except according to those terms.
 
 use mysql_common::{
+    auth::{self, plugins::PluginInitError},
     named_params::MixedParamsError,
     packets::{self, BulkExecuteRequestBuilderError, BulkExecuteRequestError},
     params::ParamsError,
@@ -117,6 +118,34 @@ impl error::Error for Error {
     }
 }
 
+impl From<PluginInitError> for Error {
+    fn from(value: PluginInitError) -> Self {
+        Self::DriverError(DriverError::from(value))
+    }
+}
+
+impl From<PluginInitError> for DriverError {
+    fn from(value: PluginInitError) -> Self {
+        match value {
+            PluginInitError::UnsupportedPlugin(name) => {
+                DriverError::UnknownAuthPlugin(String::from_utf8_lossy(&name).into_owned())
+            }
+        }
+    }
+}
+
+impl From<auth::plugins::Error> for Error {
+    fn from(value: auth::plugins::Error) -> Self {
+        Self::DriverError(DriverError::from(value))
+    }
+}
+
+impl From<auth::plugins::Error> for DriverError {
+    fn from(value: auth::plugins::Error) -> Self {
+        DriverError::AuthPlugin(value)
+    }
+}
+
 impl From<FromValueError> for Error {
     fn from(FromValueError(value): FromValueError) -> Error {
         Error::FromValueError(value)
@@ -199,7 +228,7 @@ impl fmt::Debug for Error {
     }
 }
 
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq)]
 pub enum DriverError {
     ConnectTimeout,
     // (address, description)
@@ -223,8 +252,8 @@ pub enum DriverError {
     OldMysqlPasswordDisabled,
     CleartextPluginDisabled,
     BulkExecute(BulkExecuteRequestError),
-    InvalidParsecSalt,
     CertificateCannotBeValidated,
+    AuthPlugin(auth::plugins::Error),
 }
 
 impl From<BulkExecuteRequestBuilderError> for DriverError {
@@ -310,11 +339,11 @@ impl fmt::Display for DriverError {
             DriverError::BulkExecute(e) => {
                 write!(f, "Bulk execute error: {e}")
             }
-            DriverError::InvalidParsecSalt => {
-                write!(f, "Could not parse Parsec extended salt packet")
-            }
             DriverError::CertificateCannotBeValidated => {
                 write!(f, "Server certificate cannot be validated")
+            }
+            DriverError::AuthPlugin(error) => {
+                write!(f, "Auth plugin error: {}", error)
             }
         }
     }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -135,6 +135,16 @@ impl Stream {
             })
     }
 
+    #[cfg(any(feature = "native-tls", feature = "rustls"))]
+    pub fn is_secure(&self) -> bool {
+        matches!(self, Stream::TcpStream(TcpStream::Secure(_)))
+    }
+
+    #[cfg(not(any(feature = "native-tls", feature = "rustls")))]
+    pub fn is_secure(&self) -> bool {
+        false
+    }
+
     pub fn is_insecure(&self) -> bool {
         matches!(self, Stream::TcpStream(TcpStream::Insecure(_)))
     }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -144,7 +144,14 @@ impl Stream {
     }
 
     #[cfg(all(not(feature = "native-tls"), not(feature = "rustls")))]
-    pub fn make_secure(self, _host: url::Host, _ssl_opts: crate::SslOpts) -> MyResult<Stream> {
+    pub fn make_secure(
+        self,
+        _host: url::Host,
+        _ssl_opts: crate::SslOpts,
+        _zero_config_check: Option<
+            std::sync::Arc<std::sync::Mutex<Option<mysql_common::crypto::MariaDbZeroConfigCheck>>>,
+        >,
+    ) -> MyResult<Stream> {
         panic!(
             "Client had asked for TLS connection but TLS support is disabled. \
             Please enable one of the following features: \"native-tls\", \"rustls-tls\", \"rustls-tls-ring\""

--- a/src/io/tcp.rs
+++ b/src/io/tcp.rs
@@ -161,22 +161,28 @@ impl<T: ToSocketAddrs> MyTcpBuilder<T> {
             }
         } else {
             // no bind address
-            addrs
-                .into_iter()
-                .try_fold(None, |prev, sock_addr| match prev {
-                    Some(x) => io::Result::Ok(Some(x)),
-                    None => {
-                        let domain = Domain::for_address(sock_addr);
-                        let socket = Socket::new(domain, Type::STREAM, None)?;
-                        if let Some(connect_timeout) = connect_timeout {
-                            socket.connect_timeout(&sock_addr.into(), connect_timeout)?;
-                        } else {
-                            socket.connect(&sock_addr.into())?;
-                        }
-                        Ok(Some(socket))
+            let mut last_result = None;
+            for sock_addr in addrs {
+                let domain = Domain::for_address(sock_addr);
+                let socket = Socket::new(domain, Type::STREAM, None)?;
+
+                let result = if let Some(connect_timeout) = connect_timeout {
+                    socket.connect_timeout(&sock_addr.into(), connect_timeout)
+                } else {
+                    socket.connect(&sock_addr.into())
+                };
+
+                last_result = Some(result.map(|_| socket));
+
+                match last_result.as_ref() {
+                    Some(Ok(_)) => break,
+                    Some(Err(e)) if e.kind() == io::ErrorKind::ConnectionRefused => {
+                        continue;
                     }
-                })?
-                .ok_or(err)
+                    _ => break,
+                }
+            }
+            last_result.unwrap_or(Err(err))
         }?;
 
         socket.set_read_timeout(read_timeout)?;

--- a/src/io/tls/native_tls_io.rs
+++ b/src/io/tls/native_tls_io.rs
@@ -20,6 +20,7 @@ impl Stream {
         self,
         host: url::Host,
         ssl_opts: SslOpts,
+        // At the moment zero config validation is not possible with native-tls
         _zero_config_check: Option<Arc<Mutex<Option<MariaDbZeroConfigCheck>>>>,
     ) -> Result<Stream> {
         if self.is_socket() {

--- a/src/io/tls/native_tls_io.rs
+++ b/src/io/tls/native_tls_io.rs
@@ -3,9 +3,11 @@
 use std::{
     fs::File,
     io::{self, Read},
+    sync::{Arc, Mutex},
 };
 
 use bufstream::BufStream;
+use mysql_common::crypto::MariaDbZeroConfigCheck;
 use native_tls::{Certificate, TlsConnector};
 
 use crate::{
@@ -14,7 +16,12 @@ use crate::{
 };
 
 impl Stream {
-    pub fn make_secure(self, host: url::Host, ssl_opts: SslOpts) -> Result<Stream> {
+    pub fn make_secure(
+        self,
+        host: url::Host,
+        ssl_opts: SslOpts,
+        _zero_config_check: Option<Arc<Mutex<Option<MariaDbZeroConfigCheck>>>>,
+    ) -> Result<Stream> {
         if self.is_socket() {
             // won't secure socket connection
             return Ok(self);

--- a/src/io/tls/rustls_io.rs
+++ b/src/io/tls/rustls_io.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use bufstream::BufStream;
+use mysql_common::crypto::MariaDbZeroConfigCheck;
 use rustls::{
     client::{
         danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
@@ -16,14 +17,14 @@ use rustls::{
     CertificateError, ClientConfig, Error, RootCertStore, SignatureScheme,
 };
 use rustls_pemfile::certs;
+use sha2::{Digest, Sha256};
+use x509_parser::{asn1_rs::FromDer, certificate::X509Certificate};
 
 use crate::{
     error::tls::TlsError,
     io::{Stream, TcpStream},
     Result, SslOpts,
 };
-use mysql_common::crypto::MariaDbZeroConfigCheck;
-use sha2::{Digest, Sha256};
 
 impl Stream {
     pub fn make_secure(
@@ -172,14 +173,25 @@ impl ServerCertVerifier for DangerousVerifier {
                 {
                     Ok(ServerCertVerified::assertion())
                 }
-                Err(_e) if self.zero_config_check.is_some() => {
-                    if let Some(zero_config_check) = &self.zero_config_check {
-                        let mut hasher = Sha256::new();
-                        hasher.update(end_entity.as_ref());
-                        let fingerprint = hasher.finalize().to_vec();
-                        if let Ok(mut guard) = zero_config_check.lock() {
-                            *guard = Some(MariaDbZeroConfigCheck::new(Some(fingerprint)));
-                        }
+                // MariaDb zero-config TLS
+                Err(Error::InvalidCertificate(CertificateError::UnknownIssuer))
+                    if let Some(zero_config_check) = &self.zero_config_check =>
+                {
+                    // Let's check that it is a self-signed certificate
+                    let self_signed = X509Certificate::from_der(end_entity.as_ref())
+                        .map(|(_, cert)| cert.issuer() == cert.subject())
+                        .unwrap_or_default();
+
+                    if !self_signed {
+                        // MariaDb zero-config TLS is for self-signed ephimeral server certs only
+                        return Err(Error::InvalidCertificate(CertificateError::UnknownIssuer));
+                    }
+
+                    let mut hasher = Sha256::new();
+                    hasher.update(end_entity.as_ref());
+                    let fingerprint = hasher.finalize().to_vec();
+                    if let Ok(mut guard) = zero_config_check.lock() {
+                        *guard = Some(MariaDbZeroConfigCheck::new(Some(fingerprint)));
                     }
 
                     Ok(ServerCertVerified::assertion())

--- a/src/io/tls/rustls_io.rs
+++ b/src/io/tls/rustls_io.rs
@@ -3,7 +3,7 @@
 use std::{
     fs::File,
     io::{self, Read},
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 use bufstream::BufStream;
@@ -22,9 +22,16 @@ use crate::{
     io::{Stream, TcpStream},
     Result, SslOpts,
 };
+use mysql_common::crypto::MariaDbZeroConfigCheck;
+use sha2::{Digest, Sha256};
 
 impl Stream {
-    pub fn make_secure(self, host: url::Host, ssl_opts: SslOpts) -> Result<Stream> {
+    pub fn make_secure(
+        self,
+        host: url::Host,
+        ssl_opts: SslOpts,
+        zero_config_check: Option<Arc<Mutex<Option<MariaDbZeroConfigCheck>>>>,
+    ) -> Result<Stream> {
         if self.is_socket() {
             // won't secure socket connection
             return Ok(self);
@@ -78,6 +85,7 @@ impl Stream {
             ssl_opts.accept_invalid_certs(),
             ssl_opts.skip_domain_validation(),
             web_pki_verifier,
+            zero_config_check,
         );
         dangerous.set_certificate_verifier(Arc::new(dangerous_verifier));
 
@@ -102,11 +110,25 @@ impl Stream {
     }
 }
 
-#[derive(Debug)]
 struct DangerousVerifier {
     accept_invalid_certs: bool,
     skip_domain_validation: bool,
     verifier: Arc<WebPkiServerVerifier>,
+    zero_config_check: Option<Arc<Mutex<Option<MariaDbZeroConfigCheck>>>>,
+}
+
+impl std::fmt::Debug for DangerousVerifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DangerousVerifier")
+            .field("accept_invalid_certs", &self.accept_invalid_certs)
+            .field("skip_domain_validation", &self.skip_domain_validation)
+            .field("verifier", &self.verifier)
+            .field(
+                "zero_config_check",
+                &self.zero_config_check.as_ref().map(|_| "<hidden>"),
+            )
+            .finish()
+    }
 }
 
 impl DangerousVerifier {
@@ -114,11 +136,13 @@ impl DangerousVerifier {
         accept_invalid_certs: bool,
         skip_domain_validation: bool,
         verifier: Arc<WebPkiServerVerifier>,
+        zero_config_check: Option<Arc<Mutex<Option<MariaDbZeroConfigCheck>>>>,
     ) -> Self {
         Self {
             accept_invalid_certs,
             skip_domain_validation,
             verifier,
+            zero_config_check,
         }
     }
 }
@@ -146,6 +170,18 @@ impl ServerCertVerifier for DangerousVerifier {
                 Err(Error::InvalidCertificate(CertificateError::NotValidForName))
                     if self.skip_domain_validation =>
                 {
+                    Ok(ServerCertVerified::assertion())
+                }
+                Err(_e) if self.zero_config_check.is_some() => {
+                    if let Some(zero_config_check) = &self.zero_config_check {
+                        let mut hasher = Sha256::new();
+                        hasher.update(end_entity.as_ref());
+                        let fingerprint = hasher.finalize().to_vec();
+                        if let Ok(mut guard) = zero_config_check.lock() {
+                            *guard = Some(MariaDbZeroConfigCheck::new(Some(fingerprint)));
+                        }
+                    }
+
                     Ok(ServerCertVerified::assertion())
                 }
                 Err(e) => Err(e),


### PR DESCRIPTION
"Zero Config SSL" allows easy secure encrypted connection configuration with MariaDB server versions 11.4.1+. The only thing the application need for that is request encrypted connection and require certificate validation. The server can generate ephemeral certificate if needed. In case normal certificate validation failed the client still have chance to ensure that the certificate is valid and connection is secure. For this purpose the server sends additional information - SHA256(password_hash || scramble || certificate fingerprint)). The client knows all three parts required to calculate this signature. If calculated and received hashes match - the certificate is considered validated and the connection - secure.
This won't work with empty user passwords and insecure authentication plugins. i.e. it only work with native password, ed25519 and parsec plugins. In such case the error returned that the certificate could not be validated.

The feature is only supported with rustls backend only and not with nativetls.