### PR TITLE
Update lru to 0.18.2 due RUSTSEC-2026-0253

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ crossbeam-queue = "0.3.12"
 crossbeam-utils = "0.8.21"
 flate2 = { version = "1.0", default-features = false }
 io-enum = "1.0.0"
-lru = { version = "0.16.3", default-features = false }
+lru = { version = "0.18.2", default-features = false }
 mysql_common = { version = "0.38.2", default-features = false }
 native-tls = { version = "0.2.3", optional = true }
 pem = "3"


### PR DESCRIPTION
This patch updates lru dependency to 0.18.2 because 0.16.4 currently used has [RUSTSEC-2026-0253](https://rustsec.org/advisories/RUSTSEC-2026-0253.html).

All eight CI configurations, 754 tests are passing with new version of lru.